### PR TITLE
[Chore] View 미리보기용 파일 생성#6

### DIFF
--- a/SNAPFIT/SNAPFIT.xcodeproj/project.pbxproj
+++ b/SNAPFIT/SNAPFIT.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		6A013C8B2A08E6EF00DF2FF4 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 6A013C8A2A08E6EF00DF2FF4 /* SnapKit */; };
+		6A1CFD332A0D1C29006971AE /* Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1CFD322A0D1C29006971AE /* Preview.swift */; };
 		C77784782A003B1000B4AB8D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77784772A003B1000B4AB8D /* AppDelegate.swift */; };
 		C777847A2A003B1000B4AB8D /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77784792A003B1000B4AB8D /* SceneDelegate.swift */; };
 		C777847C2A003B1000B4AB8D /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C777847B2A003B1000B4AB8D /* HomeViewController.swift */; };
@@ -34,6 +35,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		6A1CFD322A0D1C29006971AE /* Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preview.swift; sourceTree = "<group>"; };
 		C77784742A003B1000B4AB8D /* SNAPFIT.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SNAPFIT.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C77784772A003B1000B4AB8D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C77784792A003B1000B4AB8D /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -135,6 +137,7 @@
 			children = (
 				C7E900242A0BC17300CC620B /* Screens */,
 				C77784822A003B1100B4AB8D /* LaunchScreen.storyboard */,
+				6A1CFD322A0D1C29006971AE /* Preview.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -315,6 +318,7 @@
 				C7E900332A0BCA3800CC620B /* BaseResponseType.swift in Sources */,
 				C7E9002E2A0BC99C00CC620B /* NetworkResult.swift in Sources */,
 				C7E9001A2A0BBFF000CC620B /* UIFont+.swift in Sources */,
+				6A1CFD332A0D1C29006971AE /* Preview.swift in Sources */,
 				C7E9002C2A0BC92200CC620B /* APIConstants.swift in Sources */,
 				C77784782A003B1000B4AB8D /* AppDelegate.swift in Sources */,
 				C777847A2A003B1000B4AB8D /* SceneDelegate.swift in Sources */,

--- a/SNAPFIT/SNAPFIT/Sources/Preview.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Preview.swift
@@ -1,0 +1,27 @@
+//
+//  Preview.swift
+//  SNAPFIT
+//
+//  Created by 강유진 on 2023/05/11.
+//
+
+import SwiftUI
+
+struct ViewToPreview: UIViewControllerRepresentable{
+
+    typealias UIViewControllerType = HomeViewController
+    let targetView = HomeViewController()
+    
+    func makeUIViewController(context: Context) -> UIViewControllerType {
+        return targetView
+    }
+    
+    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {
+    }
+}
+
+struct Preview: PreviewProvider {
+    static var previews: some View{
+        ViewToPreview()
+    }
+}


### PR DESCRIPTION
## 작업한 내용
- 파일 'Preview' 생성
- Preview용 구조체 생성
- 미리보기할 뷰를 HomeViewController로 설정함
- 파일은 Sources에 저장. 다른 모든 뷰에 사용할 수 있으며 개발에 사용되는 소스이기 때문
- [참고문헌: 내 블로그 예전에 썼던 글](https://hamthoven.hashnode.dev/uikit-preview-in-uikit) 


## PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 나중에 쓸 일 생기면 [여기](https://hamthoven.hashnode.dev/uikit-preview-in-uikit#heading-7iks7jqp7zwgioyimcdsnojripqg7jyg7jqp7zwcioygjeyeseutpa)에서 유용한 속성들 정리해뒀다! 나중에 쓰고싶어질 수도 있으니 노션에도 사용법 대충 적어둘게


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
![image](https://github.com/2023-SWU-Snapfit/SNAPFIT-iOS/assets/86394389/8b7ca81d-cf6c-4a7a-93b1-7b1a42907289)


## 관련 이슈
- Resolved: #6


<!-- Assignee, Reviewer 설정! 😇 -->
