### PR TITLE
[CHORE] Base UIClass 및 Util 메서드 추가

### DIFF
--- a/SNAPFIT/SNAPFIT.xcodeproj/project.pbxproj
+++ b/SNAPFIT/SNAPFIT.xcodeproj/project.pbxproj
@@ -9,6 +9,27 @@
 /* Begin PBXBuildFile section */
 		6A013C8B2A08E6EF00DF2FF4 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 6A013C8A2A08E6EF00DF2FF4 /* SnapKit */; };
 		6A1CFD332A0D1C29006971AE /* Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1CFD322A0D1C29006971AE /* Preview.swift */; };
+		C766F1582A1097AF009BC30E /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C766F1572A1097AF009BC30E /* BaseViewController.swift */; };
+		C766F15B2A109806009BC30E /* SnapfitActivityIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C766F15A2A109806009BC30E /* SnapfitActivityIndicatorView.swift */; };
+		C766F15D2A1098D3009BC30E /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C766F15C2A1098D3009BC30E /* UIViewController+.swift */; };
+		C766F1602A109AAB009BC30E /* ClassName.swift in Sources */ = {isa = PBXBuildFile; fileRef = C766F15F2A109AAB009BC30E /* ClassName.swift */; };
+		C766F1622A109C06009BC30E /* BaseNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C766F1612A109C06009BC30E /* BaseNavigationController.swift */; };
+		C766F1642A10A171009BC30E /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = C766F1632A10A171009BC30E /* Message.swift */; };
+		C766F1682A10A1C8009BC30E /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C766F1672A10A1C8009BC30E /* UILabel+.swift */; };
+		C766F16A2A10A200009BC30E /* UICollectionView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C766F1692A10A200009BC30E /* UICollectionView+.swift */; };
+		C766F16C2A10A232009BC30E /* UITableView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C766F16B2A10A232009BC30E /* UITableView+.swift */; };
+		C766F16E2A10A25A009BC30E /* UITextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = C766F16D2A10A25A009BC30E /* UITextField.swift */; };
+		C766F1702A10A27A009BC30E /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C766F16F2A10A27A009BC30E /* UIView+.swift */; };
+		C766F1722A10A2B3009BC30E /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C766F1712A10A2B2009BC30E /* UIButton+.swift */; };
+		C766F1742A10A3B6009BC30E /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C766F1732A10A3B6009BC30E /* String+.swift */; };
+		C766F1762A10A3FB009BC30E /* ImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C766F1752A10A3FB009BC30E /* ImageCacheManager.swift */; };
+		C766F1782A10A41C009BC30E /* UserDefaults+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C766F1772A10A41C009BC30E /* UserDefaults+.swift */; };
+		C766F17A2A10A43F009BC30E /* UIStackView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C766F1792A10A43F009BC30E /* UIStackView+.swift */; };
+		C766F17C2A10A455009BC30E /* UIImageView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C766F17B2A10A455009BC30E /* UIImageView+.swift */; };
+		C766F17E2A10A47B009BC30E /* Notification+Name+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C766F17D2A10A47B009BC30E /* Notification+Name+.swift */; };
+		C766F1802A10A49C009BC30E /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = C766F17F2A10A49C009BC30E /* UIImage+.swift */; };
+		C766F1822A10A4E3009BC30E /* UINavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C766F1812A10A4E3009BC30E /* UINavigationController.swift */; };
+		C766F1842A10A507009BC30E /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C766F1832A10A507009BC30E /* UserDefaultsManager.swift */; };
 		C77784782A003B1000B4AB8D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77784772A003B1000B4AB8D /* AppDelegate.swift */; };
 		C777847A2A003B1000B4AB8D /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77784792A003B1000B4AB8D /* SceneDelegate.swift */; };
 		C777847C2A003B1000B4AB8D /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C777847B2A003B1000B4AB8D /* HomeViewController.swift */; };
@@ -36,6 +57,27 @@
 
 /* Begin PBXFileReference section */
 		6A1CFD322A0D1C29006971AE /* Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preview.swift; sourceTree = "<group>"; };
+		C766F1572A1097AF009BC30E /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
+		C766F15A2A109806009BC30E /* SnapfitActivityIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapfitActivityIndicatorView.swift; sourceTree = "<group>"; };
+		C766F15C2A1098D3009BC30E /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
+		C766F15F2A109AAB009BC30E /* ClassName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClassName.swift; sourceTree = "<group>"; };
+		C766F1612A109C06009BC30E /* BaseNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseNavigationController.swift; sourceTree = "<group>"; };
+		C766F1632A10A171009BC30E /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
+		C766F1672A10A1C8009BC30E /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
+		C766F1692A10A200009BC30E /* UICollectionView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView+.swift"; sourceTree = "<group>"; };
+		C766F16B2A10A232009BC30E /* UITableView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+.swift"; sourceTree = "<group>"; };
+		C766F16D2A10A25A009BC30E /* UITextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITextField.swift; sourceTree = "<group>"; };
+		C766F16F2A10A27A009BC30E /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
+		C766F1712A10A2B2009BC30E /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
+		C766F1732A10A3B6009BC30E /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
+		C766F1752A10A3FB009BC30E /* ImageCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheManager.swift; sourceTree = "<group>"; };
+		C766F1772A10A41C009BC30E /* UserDefaults+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+.swift"; sourceTree = "<group>"; };
+		C766F1792A10A43F009BC30E /* UIStackView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+.swift"; sourceTree = "<group>"; };
+		C766F17B2A10A455009BC30E /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
+		C766F17D2A10A47B009BC30E /* Notification+Name+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification+Name+.swift"; sourceTree = "<group>"; };
+		C766F17F2A10A49C009BC30E /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
+		C766F1812A10A4E3009BC30E /* UINavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UINavigationController.swift; sourceTree = "<group>"; };
+		C766F1832A10A507009BC30E /* UserDefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManager.swift; sourceTree = "<group>"; };
 		C77784742A003B1000B4AB8D /* SNAPFIT.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SNAPFIT.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C77784772A003B1000B4AB8D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C77784792A003B1000B4AB8D /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -75,6 +117,33 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		C766F1562A1097A2009BC30E /* Bases */ = {
+			isa = PBXGroup;
+			children = (
+				C766F1572A1097AF009BC30E /* BaseViewController.swift */,
+				C766F1612A109C06009BC30E /* BaseNavigationController.swift */,
+			);
+			path = Bases;
+			sourceTree = "<group>";
+		};
+		C766F1592A1097F1009BC30E /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				C766F15A2A109806009BC30E /* SnapfitActivityIndicatorView.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		C766F15E2A109AA1009BC30E /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				C766F15F2A109AAB009BC30E /* ClassName.swift */,
+				C766F1632A10A171009BC30E /* Message.swift */,
+				C766F1832A10A507009BC30E /* UserDefaultsManager.swift */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
 		C777846B2A003B1000B4AB8D = {
 			isa = PBXGroup;
 			children = (
@@ -107,6 +176,8 @@
 		C7E9000B2A0BBBEC00CC620B /* Global */ = {
 			isa = PBXGroup;
 			children = (
+				C766F15E2A109AA1009BC30E /* Utils */,
+				C766F1562A1097A2009BC30E /* Bases */,
 				C7E900162A0BBFB200CC620B /* Extensions */,
 				C7E900112A0BBC7400CC620B /* Singletons */,
 			);
@@ -135,6 +206,7 @@
 		C7E9000E2A0BBC0500CC620B /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				C766F1592A1097F1009BC30E /* Components */,
 				C7E900242A0BC17300CC620B /* Screens */,
 				C77784822A003B1100B4AB8D /* LaunchScreen.storyboard */,
 				6A1CFD322A0D1C29006971AE /* Preview.swift */,
@@ -165,6 +237,7 @@
 			isa = PBXGroup;
 			children = (
 				C7E900122A0BBC8200CC620B /* UserInfo.swift */,
+				C766F1752A10A3FB009BC30E /* ImageCacheManager.swift */,
 			);
 			path = Singletons;
 			sourceTree = "<group>";
@@ -175,6 +248,20 @@
 				C7E900172A0BBFC000CC620B /* UIColor+.swift */,
 				C7E900192A0BBFF000CC620B /* UIFont+.swift */,
 				C7E900282A0BC58000CC620B /* Bundle+.swift */,
+				C766F15C2A1098D3009BC30E /* UIViewController+.swift */,
+				C766F1672A10A1C8009BC30E /* UILabel+.swift */,
+				C766F1692A10A200009BC30E /* UICollectionView+.swift */,
+				C766F16B2A10A232009BC30E /* UITableView+.swift */,
+				C766F16D2A10A25A009BC30E /* UITextField.swift */,
+				C766F16F2A10A27A009BC30E /* UIView+.swift */,
+				C766F1712A10A2B2009BC30E /* UIButton+.swift */,
+				C766F1732A10A3B6009BC30E /* String+.swift */,
+				C766F1772A10A41C009BC30E /* UserDefaults+.swift */,
+				C766F1792A10A43F009BC30E /* UIStackView+.swift */,
+				C766F17B2A10A455009BC30E /* UIImageView+.swift */,
+				C766F17D2A10A47B009BC30E /* Notification+Name+.swift */,
+				C766F17F2A10A49C009BC30E /* UIImage+.swift */,
+				C766F1812A10A4E3009BC30E /* UINavigationController.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -313,16 +400,37 @@
 			files = (
 				C7E900132A0BBC8200CC620B /* UserInfo.swift in Sources */,
 				C7E900352A0BCAE200CC620B /* NetworkLoggerPlugin.swift in Sources */,
+				C766F1842A10A507009BC30E /* UserDefaultsManager.swift in Sources */,
+				C766F17A2A10A43F009BC30E /* UIStackView+.swift in Sources */,
+				C766F16E2A10A25A009BC30E /* UITextField.swift in Sources */,
+				C766F1682A10A1C8009BC30E /* UILabel+.swift in Sources */,
 				C7E900292A0BC58000CC620B /* Bundle+.swift in Sources */,
 				C777847C2A003B1000B4AB8D /* HomeViewController.swift in Sources */,
 				C7E900332A0BCA3800CC620B /* BaseResponseType.swift in Sources */,
+				C766F1582A1097AF009BC30E /* BaseViewController.swift in Sources */,
 				C7E9002E2A0BC99C00CC620B /* NetworkResult.swift in Sources */,
+				C766F1722A10A2B3009BC30E /* UIButton+.swift in Sources */,
+				C766F1742A10A3B6009BC30E /* String+.swift in Sources */,
+				C766F1762A10A3FB009BC30E /* ImageCacheManager.swift in Sources */,
+				C766F1642A10A171009BC30E /* Message.swift in Sources */,
 				C7E9001A2A0BBFF000CC620B /* UIFont+.swift in Sources */,
 				6A1CFD332A0D1C29006971AE /* Preview.swift in Sources */,
+				C766F1702A10A27A009BC30E /* UIView+.swift in Sources */,
+				C766F1782A10A41C009BC30E /* UserDefaults+.swift in Sources */,
+				C766F1602A109AAB009BC30E /* ClassName.swift in Sources */,
 				C7E9002C2A0BC92200CC620B /* APIConstants.swift in Sources */,
+				C766F15D2A1098D3009BC30E /* UIViewController+.swift in Sources */,
+				C766F1802A10A49C009BC30E /* UIImage+.swift in Sources */,
+				C766F15B2A109806009BC30E /* SnapfitActivityIndicatorView.swift in Sources */,
+				C766F16C2A10A232009BC30E /* UITableView+.swift in Sources */,
+				C766F1822A10A4E3009BC30E /* UINavigationController.swift in Sources */,
 				C77784782A003B1000B4AB8D /* AppDelegate.swift in Sources */,
+				C766F17C2A10A455009BC30E /* UIImageView+.swift in Sources */,
+				C766F1622A109C06009BC30E /* BaseNavigationController.swift in Sources */,
 				C777847A2A003B1000B4AB8D /* SceneDelegate.swift in Sources */,
 				C7E900182A0BBFC000CC620B /* UIColor+.swift in Sources */,
+				C766F16A2A10A200009BC30E /* UICollectionView+.swift in Sources */,
+				C766F17E2A10A47B009BC30E /* Notification+Name+.swift in Sources */,
 				C7E900302A0BC9D600CC620B /* BaseAPI.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SNAPFIT/SNAPFIT/Global/Bases/BaseNavigationController.swift
+++ b/SNAPFIT/SNAPFIT/Global/Bases/BaseNavigationController.swift
@@ -1,0 +1,32 @@
+//
+//  BaseNavigationController.swift
+//  SNAPFIT
+//
+//  Created by madilyn on 2023/05/14.
+//
+
+import UIKit
+
+class BaseNavigationController: UINavigationController {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.interactivePopGestureRecognizer?.delegate = self
+        self.hideNavigationBar()
+    }
+}
+
+// MARK: - UIGestureRecognizerDelegate
+
+extension BaseNavigationController: UIGestureRecognizerDelegate {
+    
+    /// NavigationBar를 안 쓰고 UIView로 네비바를 구현할 때, 스와이프로 뒤로 가기 가능하게 함
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        return self.viewControllers.count > 1
+    }
+    
+    func hideNavigationBar() {
+        self.navigationBar.isHidden = true
+    }
+}

--- a/SNAPFIT/SNAPFIT/Global/Bases/BaseViewController.swift
+++ b/SNAPFIT/SNAPFIT/Global/Bases/BaseViewController.swift
@@ -1,0 +1,72 @@
+//
+//  BaseViewController.swift
+//  SNAPFIT
+//
+//  Created by madilyn on 2023/05/14.
+//
+
+import UIKit
+
+class BaseViewController: UIViewController, UIGestureRecognizerDelegate {
+    
+    // MARK: Properties
+    
+    lazy var activityIndicator: SnapfitActivityIndicatorView = {
+        let activityIndicator: SnapfitActivityIndicatorView = SnapfitActivityIndicatorView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        activityIndicator.center = self.view.center
+        
+        return activityIndicator
+    }()
+    
+    let screenWidth = UIScreen.main.bounds.size.width
+    let screenHeight = UIScreen.main.bounds.size.height
+    
+    // MARK: View Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.setSnapfitBackgroundColor()
+    }
+}
+
+// MARK: Methods
+
+extension BaseViewController {
+//    func hideTabbar() {
+//        if let tabBarController = self.tabBarController as? SnapfitTabBarController {
+//            tabBarController.hideTabbar()
+//        }
+//    }
+//
+//    func showTabbar() {
+//        if let tabBarController = self.tabBarController as? SnapfitTabBarController {
+//            tabBarController.showTabbar()
+//        }
+//    }
+    
+    /// 화면 터치 시 키보드 내리는 메서드
+    func hideKeyboardWhenTappedAround() {
+        let tap: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(UIViewController.dismissKeyboard))
+        tap.delegate = self
+        tap.cancelsTouchesInView = false
+        view.addGestureRecognizer(tap)
+    }
+    
+    /// 모든 뷰의 기본 Background color 설정
+    private func setSnapfitBackgroundColor() {
+        self.view.backgroundColor = .sfGrayWhite
+    }
+    
+    /// 서버 통신 시작 시 Activity Indicator를 시작하는 메서드
+    func startActivityIndicator() {
+        self.view.addSubview(self.activityIndicator)
+        self.activityIndicator.startAnimating()
+    }
+    
+    /// 서버 통신이 끝나면 Activity Indicator를 종료하는 메서드
+    func stopActivityIndicator() {
+        self.activityIndicator.stopAnimating()
+        self.activityIndicator.removeFromSuperview()
+    }
+}

--- a/SNAPFIT/SNAPFIT/Global/Bases/BaseViewController.swift
+++ b/SNAPFIT/SNAPFIT/Global/Bases/BaseViewController.swift
@@ -26,7 +26,7 @@ class BaseViewController: UIViewController, UIGestureRecognizerDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.setSnapfitBackgroundColor()
+        self.setBackgroundColor()
     }
 }
 
@@ -54,7 +54,7 @@ extension BaseViewController {
     }
     
     /// 모든 뷰의 기본 Background color 설정
-    private func setSnapfitBackgroundColor() {
+    private func setBackgroundColor() {
         self.view.backgroundColor = .sfGrayWhite
     }
     

--- a/SNAPFIT/SNAPFIT/Global/Extensions/Notification+Name+.swift
+++ b/SNAPFIT/SNAPFIT/Global/Extensions/Notification+Name+.swift
@@ -1,0 +1,12 @@
+//
+//  Notification+Name+.swift
+//  SNAPFIT
+//
+//  Created by madilyn on 2023/05/14.
+//
+
+import Foundation
+
+extension Notification.Name {
+    static let sendViewState = Notification.Name("sendViewState")
+}

--- a/SNAPFIT/SNAPFIT/Global/Extensions/String+.swift
+++ b/SNAPFIT/SNAPFIT/Global/Extensions/String+.swift
@@ -1,0 +1,35 @@
+//
+//  String+.swift
+//  SNAPFIT
+//
+//  Created by madilyn on 2023/05/14.
+//
+
+import Foundation
+import UIKit.UIImage
+
+extension String {
+    func getImage(completion: @escaping (UIImage) -> ()){
+        let cacheKey = NSString(string: self)
+        
+        /// 해당 Key에 캐시 이미지가 저장되어 있으면 이미지 사용
+        if let cachedImage = ImageCacheManager.shared.object(forKey: cacheKey) {
+            completion(cachedImage)
+        }
+        
+        if let requestURL = URL(string: self) {
+            let request = URLRequest(url: requestURL)
+            
+            URLSession.shared.dataTask(with: request) { data, response, error in
+                if let data = data,
+                   let response = response, ((response as? HTTPURLResponse)?.statusCode ?? 500) < 300,
+                   let image = UIImage(data: data) {
+                    
+                    /// 다운받은 이미지를 캐시에 저장
+                    ImageCacheManager.shared.setObject(image, forKey: cacheKey)
+                    completion(image)
+                }
+            }.resume()
+        }
+    }
+}

--- a/SNAPFIT/SNAPFIT/Global/Extensions/UIButton+.swift
+++ b/SNAPFIT/SNAPFIT/Global/Extensions/UIButton+.swift
@@ -1,0 +1,34 @@
+//
+//  UIButton+.swift
+//  SNAPFIT
+//
+//  Created by madilyn on 2023/05/14.
+//
+
+import UIKit.UIButton
+
+extension UIButton {
+    public func setBackgroundColor(_ color: UIColor, for state: UIControl.State) {
+        let minimumSize: CGSize = CGSize(width: 1.0, height: 1.0)
+        
+        UIGraphicsBeginImageContext(minimumSize)
+        
+        if let context = UIGraphicsGetCurrentContext() {
+            context.setFillColor(color.cgColor)
+            context.fill(CGRect(origin: CGPoint.zero, size: minimumSize))
+        }
+        
+        let colorImage = UIGraphicsGetImageFromCurrentImageContext()
+        
+        self.clipsToBounds = true
+        self.setBackgroundImage(colorImage, for: state)
+    }
+    
+    /**
+     button에 대해 addTarget해서 일일이 처리하지 않고, closure 형태로 동작을 처리하기 위해 다음과 같은 extension을 활용합니다.
+     press를 작성하고, 안에 버튼이 눌렸을 때, 동작하는 함수를 만듭니다.
+     */
+    public func setAction(_ closure: @escaping () -> Void) {
+        self.addAction( UIAction { _ in closure() }, for: UIControl.Event.touchUpInside)
+    }
+}

--- a/SNAPFIT/SNAPFIT/Global/Extensions/UICollectionView+.swift
+++ b/SNAPFIT/SNAPFIT/Global/Extensions/UICollectionView+.swift
@@ -1,0 +1,49 @@
+//
+//  UICollectionView+.swift
+//  SNAPFIT
+//
+//  Created by madilyn on 2023/05/14.
+//
+
+import UIKit
+
+extension UICollectionView {
+    func dequeueReusableCell<T: UICollectionViewCell>(forIndexPath indexPath: IndexPath) -> T {
+        guard let cell = self.dequeueReusableCell(
+            withReuseIdentifier: T.className,
+            for: indexPath
+        ) as? T else {
+            fatalError("Could not find cell with reuseID \(T.className)")
+        }
+        return cell
+    }
+    
+    func dequeueHeaderView<T: UICollectionReusableView>(forIndexPath indexPath: IndexPath) -> T {
+        guard let view = dequeueReusableSupplementaryView(
+            ofKind: UICollectionView.elementKindSectionHeader,
+            withReuseIdentifier: T.className,
+            for: indexPath
+        ) as? T else {
+            fatalError("Could not dequeue cell with identifier: \(T.className)")
+        }
+        return view
+    }
+    
+    func dequeueFooterView<T: UICollectionReusableView>(forIndexPath indexPath: IndexPath) -> T {
+        guard let view = dequeueReusableSupplementaryView(
+            ofKind: UICollectionView.elementKindSectionFooter,
+            withReuseIdentifier: T.className,
+            for: indexPath
+        ) as? T else {
+            fatalError("Could not dequeue cell with identifier: \(T.className)")
+        }
+        return view
+    }
+    
+    func register<T: UICollectionViewCell>(
+        cell: T.Type,
+        forCellWithReuseIdentifier reuseIdentifier: String = T.className
+    ) {
+        register(cell, forCellWithReuseIdentifier: reuseIdentifier)
+    }
+}

--- a/SNAPFIT/SNAPFIT/Global/Extensions/UIImage+.swift
+++ b/SNAPFIT/SNAPFIT/Global/Extensions/UIImage+.swift
@@ -1,0 +1,22 @@
+//
+//  UIImage+.swift
+//  SNAPFIT
+//
+//  Created by madilyn on 2023/05/14.
+//
+
+import UIKit.UIImage
+
+extension UIImage {
+    func resizeWithWidth(width: CGFloat) -> UIImage? {
+        let imageView = UIImageView(frame: CGRect(origin: .zero, size: CGSize(width: width, height: CGFloat(ceil(width/size.width * size.height)))))
+        imageView.contentMode = .scaleAspectFit
+        imageView.image = self
+        UIGraphicsBeginImageContextWithOptions(imageView.bounds.size, false, scale)
+        guard let context = UIGraphicsGetCurrentContext() else { return nil }
+        imageView.layer.render(in: context)
+        guard let result = UIGraphicsGetImageFromCurrentImageContext() else { return nil }
+        UIGraphicsEndImageContext()
+        return result
+    }
+}

--- a/SNAPFIT/SNAPFIT/Global/Extensions/UIImageView+.swift
+++ b/SNAPFIT/SNAPFIT/Global/Extensions/UIImageView+.swift
@@ -1,0 +1,65 @@
+//
+//  UIImageView+.swift
+//  SNAPFIT
+//
+//  Created by madilyn on 2023/05/14.
+//
+
+import UIKit
+
+extension UIImageView {
+    
+    /// 그냥 컬러만 있는 Image를 ImageView에 넣어 주는 메서드
+    func setImageColor(color: UIColor) {
+        let templateImage = self.image?.withRenderingMode(.alwaysTemplate)
+        self.image = templateImage
+        self.tintColor = color
+    }
+    
+    /// URL을 통해 이미지를 불러오는 메서드 + 캐싱
+    func setImageUrl(_ imageURL: String) {
+        let cacheKey = NSString(string: imageURL)
+        
+        /// 해당 Key에 캐시 이미지가 저장되어 있으면 이미지 사용
+        if let cachedImage = ImageCacheManager.shared.object(forKey: cacheKey) {
+            self.image = cachedImage
+            return
+        }
+        
+        if let requestURL = URL(string: imageURL) {
+            let request = URLRequest(url: requestURL)
+            
+            URLSession.shared.dataTask(with: request) { data, response, error in
+                if let data = data, let response = response, ((response as? HTTPURLResponse)?.statusCode ?? 500) < 300, let image = UIImage(data: data) {
+                    
+                    /// 다운받은 이미지를 캐시에 저장
+                    ImageCacheManager.shared.setObject(image, forKey: cacheKey)
+                    
+                    DispatchQueue.main.async {
+                        self.image = image
+                    }
+                } else {
+                    DispatchQueue.main.async {
+                        self.setImageColor(color: UIColor.sfBlack20)
+                    }
+                }
+            }.resume()
+        }
+    }
+    
+    func resizeWithWidth(width: CGFloat) -> UIImage? {
+        if let currentImage = self.image {
+            let imageView = UIImageView(frame: CGRect(origin: .zero, size: CGSize(width: width, height: CGFloat(ceil(width/currentImage.size.width * currentImage.size.height)))))
+            imageView.contentMode = .scaleAspectFit
+            imageView.image = currentImage
+            UIGraphicsBeginImageContextWithOptions(imageView.bounds.size, false, currentImage.scale)
+            guard let context = UIGraphicsGetCurrentContext() else { return nil }
+            imageView.layer.render(in: context)
+            guard let result = UIGraphicsGetImageFromCurrentImageContext() else { return nil }
+            UIGraphicsEndImageContext()
+            return result
+        } else {
+            return nil
+        }
+    }
+}

--- a/SNAPFIT/SNAPFIT/Global/Extensions/UILabel+.swift
+++ b/SNAPFIT/SNAPFIT/Global/Extensions/UILabel+.swift
@@ -1,0 +1,85 @@
+//
+//  UILabel+.swift
+//  SNAPFIT
+//
+//  Created by madilyn on 2023/05/14.
+//
+
+import UIKit
+
+extension UILabel {
+    
+    /// 특정 문자열 컬러 변경하는 메서드
+    func setColor(to targetString: String, with color: UIColor) {
+        if let labelText = self.text, labelText.count > 0 {
+            let attributedString = NSMutableAttributedString(
+                attributedString: self.attributedText ?? NSAttributedString(string: labelText)
+            )
+            
+            attributedString.addAttribute(
+                .foregroundColor,
+                value: color,
+                range: (labelText as NSString).range(of: targetString)
+            )
+            
+            attributedText = attributedString
+        }
+    }
+    
+    /// 특정 문자열 폰트 변경하는 메서드
+    func setFont(to targetString: String, with font: UIFont) {
+        if let labelText = self.text, labelText.count > 0 {
+            let attributedString = NSMutableAttributedString(
+                attributedString: self.attributedText ?? NSAttributedString(string: labelText)
+            )
+            
+            attributedString.addAttribute(
+                .font,
+                value: font,
+                range: (labelText as NSString).range(of: targetString)
+            )
+            
+            attributedText = attributedString
+        }
+    }
+    
+    /// 특정 문자열 컬러, 폰트 변경하는 메서드
+    func setFontColor(to targetString: String, font: UIFont, color: UIColor) {
+        if let labelText = self.text, labelText.count > 0 {
+            let attributedString = NSMutableAttributedString(
+                attributedString: self.attributedText ?? NSAttributedString(string: labelText)
+            )
+            
+            attributedString.addAttribute(
+                .font,
+                value: font,
+                range: (labelText as NSString).range(of: targetString)
+            )
+            
+            attributedString.addAttribute(
+                .foregroundColor,
+                value: color,
+                range: (labelText as NSString).range(of: targetString))
+            
+            attributedText = attributedString
+        }
+    }
+    
+    func setHyperlinkedStyle(to targetStrings: [String], with font: UIFont
+    ) {
+        if let labelText = self.text, labelText.count > 0 {
+            let attributedString = NSMutableAttributedString(string: labelText)
+            let linkAttributes : [NSAttributedString.Key: Any] = [
+                .underlineStyle: NSUnderlineStyle.single.rawValue,
+                .font: font
+            ]
+            for targetString in targetStrings{
+                attributedString.setAttributes(
+                    linkAttributes,
+                    range: (labelText as NSString).range(of: targetString))
+            }
+            
+            attributedText = attributedString
+        }
+    }
+}

--- a/SNAPFIT/SNAPFIT/Global/Extensions/UINavigationController.swift
+++ b/SNAPFIT/SNAPFIT/Global/Extensions/UINavigationController.swift
@@ -1,0 +1,23 @@
+//
+//  UINavigationController.swift
+//  SNAPFIT
+//
+//  Created by madilyn on 2023/05/14.
+//
+
+import UIKit
+
+extension UINavigationController {
+    var previousViewController: UIViewController? {
+        self.viewControllers.count > 1 ? self.viewControllers[self.viewControllers.count - 2] : nil
+    }
+    
+    func pushViewController(_ viewController: UIViewController,
+                            animated: Bool,
+                            completion: (() -> Void)?) {
+        CATransaction.begin()
+        CATransaction.setCompletionBlock(completion)
+        pushViewController(viewController, animated: animated)
+        CATransaction.commit()
+    }
+}

--- a/SNAPFIT/SNAPFIT/Global/Extensions/UIStackView+.swift
+++ b/SNAPFIT/SNAPFIT/Global/Extensions/UIStackView+.swift
@@ -1,0 +1,27 @@
+//
+//  UIStackView+.swift
+//  SNAPFIT
+//
+//  Created by madilyn on 2023/05/14.
+//
+
+import UIKit
+
+extension UIStackView {
+    func addArrangedSubviews(_ views: [UIView]) {
+        for view in views {
+            self.addArrangedSubview(view)
+        }
+    }
+    
+    func removeAllArrangedSubviews() {
+            let removedSubviews = arrangedSubviews.reduce([]) { (allSubviews, subview) -> [UIView] in
+                self.removeArrangedSubview(subview)
+                return allSubviews + [subview]
+            }
+            // Deactivate all constraints
+            NSLayoutConstraint.deactivate(removedSubviews.flatMap({ $0.constraints }))
+            // Remove the views from self
+            removedSubviews.forEach({ $0.removeFromSuperview() })
+        }
+}

--- a/SNAPFIT/SNAPFIT/Global/Extensions/UITableView+.swift
+++ b/SNAPFIT/SNAPFIT/Global/Extensions/UITableView+.swift
@@ -1,0 +1,40 @@
+//
+//  UITableView+.swift
+//  SNAPFIT
+//
+//  Created by madilyn on 2023/05/14.
+//
+
+import UIKit
+
+extension UITableView {
+    func dequeueReusableCell<T: UITableViewCell>(withType cellType: T.Type, for indexPath: IndexPath) -> T {
+        guard let cell = self.dequeueReusableCell(withIdentifier: T.className, for: indexPath) as? T else {
+            fatalError("Could not find cell with reuseID \(T.className)")
+        }
+        return cell
+    }
+    
+    func register<T>(
+        cell: T.Type,
+        forCellReuseIdentifier reuseIdentifier: String = T.className
+    ) where T: UITableViewCell {
+        register(cell, forCellReuseIdentifier: reuseIdentifier)
+    }
+    
+    /// TableView 하단 빈 셀 없애는 메서드
+    func setBottomEmptyView() {
+        let dummyView = UIView(frame:CGRect(x: 0, y: 0, width: 0, height: 0))
+        self.tableFooterView = dummyView
+    }
+    
+    func fitContentInset(inset: UIEdgeInsets!) {
+        self.contentInset = inset
+        self.scrollIndicatorInsets = inset
+    }
+    
+    /// TableView 마지막 separator, 빈 셀 separator 숨기는 메서드
+    func removeSeparatorsOfEmptyCellsAndLastCell() {
+        tableFooterView = UIView(frame: CGRect(origin: .zero, size: CGSize(width: 0, height: 1)))
+    }
+}

--- a/SNAPFIT/SNAPFIT/Global/Extensions/UITextField.swift
+++ b/SNAPFIT/SNAPFIT/Global/Extensions/UITextField.swift
@@ -1,0 +1,40 @@
+//
+//  UITextField.swift
+//  SNAPFIT
+//
+//  Created by madilyn on 2023/05/14.
+//
+
+import UIKit
+
+extension UITextField {
+    
+    /// UITextField 왼쪽에 여백 주는 메서드
+    func addLeftPadding(_ amount: CGFloat) {
+        let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: amount, height: self.frame.size.height))
+        self.leftView = paddingView
+        self.leftViewMode = .always
+    }
+    
+    /// UITextField 오른쪽에 여백 주는 메서드
+    func addRightPadding(_ amount: CGFloat) {
+        let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: amount, height: self.frame.size.height))
+        self.rightView = paddingView
+        self.rightViewMode = .always
+    }
+    
+    /// 자간 설정 메서드
+    func setCharacterSpacing(_ spacing: CGFloat){
+        let attributedStr = NSMutableAttributedString(string: self.text ?? "")
+        attributedStr.addAttribute(NSAttributedString.Key.kern, value: spacing, range: NSMakeRange(0, attributedStr.length))
+        self.attributedText = attributedStr
+    }
+    
+    func clearSideEmptyText() -> String? {
+        if let text = self.text {
+            return text.trimmingCharacters(in: .whitespacesAndNewlines)
+        } else {
+            return nil
+        }
+    }
+}

--- a/SNAPFIT/SNAPFIT/Global/Extensions/UIView+.swift
+++ b/SNAPFIT/SNAPFIT/Global/Extensions/UIView+.swift
@@ -1,0 +1,108 @@
+//
+//  UIView+.swift
+//  SNAPFIT
+//
+//  Created by madilyn on 2023/05/14.
+//
+
+import UIKit
+
+enum VerticalLocation {
+    case bottom
+    case top
+    case left
+    case right
+    case bottomRight
+    case nadoBotttom
+}
+
+extension UIView {
+    @discardableResult
+    func makeShadow(color: UIColor,
+                    opacity: Float,
+                    offset: CGSize,
+                    radius: CGFloat) -> Self {
+        layer.shadowColor = color.cgColor
+        layer.shadowOpacity = opacity
+        layer.shadowOffset = offset
+        layer.shadowRadius = radius
+        return self
+    }
+    
+    @discardableResult
+    func setGradient(colors: [CGColor],
+                     locations: [NSNumber] = [0.0, 1.0],
+                     startPoint: CGPoint = CGPoint(x: 0.0, y: 0.0),
+                     endPoint: CGPoint = CGPoint(x: 1.0, y: 0.0)) -> Self {
+        let gradient: CAGradientLayer = CAGradientLayer()
+        gradient.colors = colors
+        gradient.locations = locations
+        gradient.startPoint = startPoint
+        gradient.endPoint = endPoint
+        gradient.frame = self.bounds
+        layer.addSublayer(gradient)
+        return self
+    }
+    
+    func addSubView<T: UIView>(_ subview: T, completionHandler closure: ((T) -> Void)? = nil) {
+        addSubview(subview)
+        closure?(subview)
+    }
+    
+    func addSubViews<T: UIView>(_ subviews: [T], completionHandler closure: (([T]) -> Void)? = nil) {
+        subviews.forEach { addSubview($0) }
+        closure?(subviews)
+    }
+    
+    func addSubviews(_ views: [UIView]) {
+        views.forEach { self.addSubview($0) }
+    }
+    
+    func addShadow(location: VerticalLocation, color: UIColor = .gray, opacity: Float = 0.2, radius: CGFloat = 5.0) {
+        switch location {
+        case .bottom:
+            addShadow(offset: CGSize(width: 0, height: 10), color: color, opacity: opacity, radius: radius)
+        case .top:
+            addShadow(offset: CGSize(width: 0, height: -4), color: color, opacity: opacity, radius: radius)
+        case .left:
+            addShadow(offset: CGSize(width: -10, height: 0), color: color, opacity: opacity, radius: radius)
+        case .right:
+            addShadow(offset: CGSize(width: 10, height: 0), color: color, opacity: opacity, radius: radius)
+        case .bottomRight:
+            addShadow(offset: CGSize(width: 3, height: 3), color: color, opacity: opacity, radius: radius)
+        case .nadoBotttom:
+            addShadow(offset: CGSize(width: 0, height: 4), color: color, opacity: opacity, radius: radius)
+        }
+        
+    }
+    
+    /// UIView의 그림자를 설정하는 메서드
+    func addShadow(offset: CGSize, color: UIColor = .sfBlack20, opacity: Float = 0.07, radius: CGFloat = 3.0) {
+        self.layer.masksToBounds = false
+        self.layer.shadowColor = color.cgColor
+        self.layer.shadowOffset = offset
+        self.layer.shadowOpacity = opacity
+        self.layer.shadowRadius = radius
+    }
+    
+    /// UIView 의 모서리가 둥근 정도를 설정하는 메서드
+    func makeRounded(cornerRadius : CGFloat?) {
+        if let cornerRadius_ = cornerRadius {
+            self.layer.cornerRadius = cornerRadius_
+        }  else {
+            // cornerRadius 가 nil 일 경우의 default
+            self.layer.cornerRadius = self.layer.frame.height / 2
+        }
+        
+        self.layer.masksToBounds = true
+    }
+    
+    /// UIView 의 모서리가 둥근 정도를 방향과 함께 설정하는 메서드
+    func roundCorners(_ corners: UIRectCorner, radius: CGFloat) {
+        let path = UIBezierPath(roundedRect: bounds, byRoundingCorners: corners,
+                                cornerRadii: CGSize(width: radius, height: radius))
+        let mask = CAShapeLayer()
+        mask.path = path.cgPath
+        layer.mask = mask
+    }
+}

--- a/SNAPFIT/SNAPFIT/Global/Extensions/UIViewController+.swift
+++ b/SNAPFIT/SNAPFIT/Global/Extensions/UIViewController+.swift
@@ -1,0 +1,102 @@
+//
+//  UIViewController+.swift
+//  SNAPFIT
+//
+//  Created by madilyn on 2023/05/14.
+//
+
+import UIKit
+
+extension UIViewController {
+    
+    /**
+     - Description: 화면 터치시 작성 종료
+     */
+    /// 화면 터치시 작성 종료하는 메서드
+    open override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.view.endEditing(true)
+    }
+    
+    /**
+     - Description: 화면 터치시 키보드 내리는 Extension
+     */
+    @objc
+    func dismissKeyboard() {
+        view.endEditing(true)
+    }
+    
+    /**
+     - Description: Alert
+     */
+    /// 확인 버튼 2개, 취소 버튼 1개 ActionSheet 메서드
+    func makeTwoAlertWithCancel(
+        okTitle: String, okStyle: UIAlertAction.Style = .default,
+        secondOkTitle: String, secondOkStyle: UIAlertAction.Style = .default,
+        cancelTitle: String = "취소",
+        okAction : ((UIAlertAction) -> Void)?, secondOkAction : ((UIAlertAction) -> Void)?,
+        cancelAction : ((UIAlertAction) -> Void)? = nil,
+        completion : (() -> Void)? = nil
+    ) {
+        
+        let generator = UIImpactFeedbackGenerator(style: .medium)
+        generator.impactOccurred()
+        
+        let alertViewController = UIAlertController(
+            title: nil, message: nil,
+            preferredStyle: .actionSheet
+        )
+        
+        let okAction = UIAlertAction(title: okTitle, style: okStyle, handler: okAction)
+        alertViewController.addAction(okAction)
+        
+        let secondOkAction = UIAlertAction(title: secondOkTitle, style: secondOkStyle, handler: secondOkAction)
+        alertViewController.addAction(secondOkAction)
+        
+        let cancelAction = UIAlertAction(title: cancelTitle, style: .cancel, handler: cancelAction)
+        alertViewController.addAction(cancelAction)
+        
+        self.present(alertViewController, animated: true, completion: completion)
+    }
+    
+    /// 확인 버튼 1개, 취소 버튼 1개 Alert 메서드
+    func makeAlertWithCancel(
+        okTitle: String, okStyle: UIAlertAction.Style = .default,
+        cancelTitle: String = "취소",
+        okAction : ((UIAlertAction) -> Void)?, cancelAction : ((UIAlertAction) -> Void)? = nil,
+        completion : (() -> Void)? = nil
+    ) {
+        
+        let generator = UIImpactFeedbackGenerator(style: .medium)
+        generator.impactOccurred()
+        
+        let alertViewController = UIAlertController(
+            title: nil, message: nil,
+            preferredStyle: .actionSheet
+        )
+        
+        let okAction = UIAlertAction(title: okTitle, style: okStyle, handler: okAction)
+        alertViewController.addAction(okAction)
+        
+        let cancelAction = UIAlertAction(title: cancelTitle, style: .cancel, handler: cancelAction)
+        alertViewController.addAction(cancelAction)
+        
+        self.present(alertViewController, animated: true, completion: completion)
+    }
+    
+    /// 확인 버튼 Alert 메서드
+    func makeAlert(
+        title : String, message : String? = nil,
+        okTitle: String = "확인", okAction : ((UIAlertAction) -> Void)? = nil,
+        completion : (() -> Void)? = nil
+    ) {
+        let generator = UIImpactFeedbackGenerator(style: .medium)
+        generator.impactOccurred()
+        let alertViewController = UIAlertController(
+            title: title, message: message,
+            preferredStyle: .alert
+        )
+        let okAction = UIAlertAction(title: okTitle, style: .default, handler: okAction)
+        alertViewController.addAction(okAction)
+        self.present(alertViewController, animated: true, completion: completion)
+    }
+}

--- a/SNAPFIT/SNAPFIT/Global/Extensions/UserDefaults+.swift
+++ b/SNAPFIT/SNAPFIT/Global/Extensions/UserDefaults+.swift
@@ -1,0 +1,16 @@
+//
+//  UserDefaults+.swift
+//  SNAPFIT
+//
+//  Created by madilyn on 2023/05/14.
+//
+
+import Foundation
+
+extension UserDefaults {
+    
+    /// UserDefaults key value가 많아지면 관리하기 어려워지므로 enum 'Keys'로 묶어 관리합니다.
+    enum Keys {
+        static var userID = "userID"
+    }
+}

--- a/SNAPFIT/SNAPFIT/Global/Singletons/ImageCacheManager.swift
+++ b/SNAPFIT/SNAPFIT/Global/Singletons/ImageCacheManager.swift
@@ -1,0 +1,14 @@
+//
+//  ImageCacheManager.swift
+//  SNAPFIT
+//
+//  Created by madilyn on 2023/05/14.
+//
+
+import UIKit
+
+/// 캐시를 저장해 놓을 싱글톤 클래스
+class ImageCacheManager {
+    static let shared = NSCache<NSString, UIImage>()
+    private init() {}
+}

--- a/SNAPFIT/SNAPFIT/Global/Utils/ClassName.swift
+++ b/SNAPFIT/SNAPFIT/Global/Utils/ClassName.swift
@@ -1,0 +1,25 @@
+//
+//  ClassName.swift
+//  SNAPFIT
+//
+//  Created by madilyn on 2023/05/14.
+//
+
+import Foundation
+
+public protocol ClassNameProtocol {
+    static var className: String { get }
+    var className: String { get }
+}
+
+public extension ClassNameProtocol {
+    static var className: String {
+        return String(describing: self)
+    }
+
+    var className: String {
+        return type(of: self).className
+    }
+}
+
+extension NSObject: ClassNameProtocol {}

--- a/SNAPFIT/SNAPFIT/Global/Utils/Message.swift
+++ b/SNAPFIT/SNAPFIT/Global/Utils/Message.swift
@@ -1,0 +1,24 @@
+//
+//  Message.swift
+//  SNAPFIT
+//
+//  Created by madilyn on 2023/05/14.
+//
+
+enum Message {
+    case networkError
+}
+
+extension Message {
+    
+    var text: String {
+        switch self {
+        case .networkError:
+            return
+"""
+네트워크 오류로 인해 연결에 실패하였습니다.
+잠시 후에 다시 시도해 주세요.
+"""
+        }
+    }
+}

--- a/SNAPFIT/SNAPFIT/Global/Utils/UserDefaultsManager.swift
+++ b/SNAPFIT/SNAPFIT/Global/Utils/UserDefaultsManager.swift
@@ -1,0 +1,15 @@
+//
+//  UserDefaultsManager.swift
+//  SNAPFIT
+//
+//  Created by madilyn on 2023/05/14.
+//
+
+import Foundation
+
+struct UserDefaultsManager {
+    static var userID: Int? {
+        get { return UserDefaults.standard.integer(forKey: UserDefaults.Keys.userID) }
+        set { UserDefaults.standard.set(newValue, forKey: UserDefaults.Keys.userID) }
+    }
+}

--- a/SNAPFIT/SNAPFIT/Sources/Components/SnapfitActivityIndicatorView.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Components/SnapfitActivityIndicatorView.swift
@@ -1,0 +1,29 @@
+//
+//  SnapfitActivityIndicatorView.swift
+//  SNAPFIT
+//
+//  Created by madilyn on 2023/05/14.
+//
+
+import UIKit
+
+final class SnapfitActivityIndicatorView: UIActivityIndicatorView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        self.setUI()
+    }
+    
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setUI() {
+        self.frame = CGRect(x: 0, y: 0, width: 100, height: 100)
+        
+        self.color = .sfMainRed
+        self.hidesWhenStopped = true
+        self.style = .medium
+        self.stopAnimating()
+    }
+}


### PR DESCRIPTION
## 작업한 내용
- `/Global/Extensions`: 작업하는 데 유용한 UI 컴포넌트의 메서드, String 등 타입에 관련한 메서드 추가 (대부분 다른 프로젝트에서 쓰던 거..)
- `/Global/Bases`
  - `BaseViewController`: Background color 설정 및 키보드 관련 메서드가 이미 정의되어 있으므로, 앞으로 모든 ViewController를 만들 때에는 UIViewController가 아닌 BaseViewController를 상속받아 씁시다!! hide/showTabbar 함수는 아직 TabBarController가 안 만들어져 있으므로 주석처리했어요!
  - `BaseNavigationController`: 앱에서 기본적으로 사용할 BaseNavigationController. 아마 이걸 상속받아서 새로운 네비컨트롤러를 만들 일은 크게 없을 것 같긴 합니다..! 기본적으로 스와이프로 뒤로가기를 구현해 두었어요
  - `/Global/Utils`
    - `ClassName`: ClassName이 필요한 모든 클래스에서, (예를 들면 cell register 등록 시 "ListTableViewCell"로 쓰던 것) `ListTableViewCell.ClassName` 하면 자동으로 해당 클래스 이름이 String으로 반환됩니다!
    - `Message`: 앱 내에서 공통적으로 사용되는 텍스트를 정의합니다. (최소 두 번 이상) 필요에 따라 각자 자유롭게 추가합시다~!
    - `UserDefaultsManager`: 흩어져 있어 중복으로 사용되거나 비슷한 이름의 UserDefaults가 사용되는 것을 막기 위해 UserDefaultsManager로 관리합니다. get/set을 이용해 바로 해당 값에 접근 가능하게 되어 있어서 사용이 더 쉽습니다!! 보면 사용법 알 거예용 이것도 자유롭게 추가하여 사용합시다~ (추가로 key string은 아예 UserDefaults+ Keys에 정의할 수 있어요)
  - `/Global/Singletons`
    - `ImageCacheManager`: 같은 url을 가지는 이미지는 앱이 실행되는 동안 싱글톤 클래스에서 cache로 처리하여 동일한 이미지의 중복 요청을 막습니다.


## PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 궁금한 점 있으면 알려주세용..!


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
<img width="370" alt="스크린샷 2023-05-14 14 22 50" src="https://github.com/2023-SWU-Snapfit/SNAPFIT-iOS/assets/43312096/d5d5c717-7096-449f-9166-49af93f8e179">

## 관련 이슈
- Resolved: #12


<!-- Assignee, Reviewer 설정! 😇 -->
