### PR TITLE
Feat/#24 관심목록, 예약 관리 셀 디자인 수정 및 탭 연결

### DIFF
--- a/SNAPFIT/SNAPFIT.xcodeproj/project.pbxproj
+++ b/SNAPFIT/SNAPFIT.xcodeproj/project.pbxproj
@@ -10,7 +10,7 @@
 		6A013C8B2A08E6EF00DF2FF4 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 6A013C8A2A08E6EF00DF2FF4 /* SnapKit */; };
 		6A0E39B32A10CD4200DC531A /* ChattingListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A0E39B12A10CD4200DC531A /* ChattingListViewController.swift */; };
 		6A0E39B42A10CD4200DC531A /* ChattingListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A0E39B22A10CD4200DC531A /* ChattingListTableViewCell.swift */; };
-		6A0E39B82A10CD4A00DC531A /* FavoriteListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A0E39B62A10CD4A00DC531A /* FavoriteListTableViewCell.swift */; };
+		6A0E39B82A10CD4A00DC531A /* BorderedTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A0E39B62A10CD4A00DC531A /* BorderedTableViewCell.swift */; };
 		6A0E39B92A10CD4A00DC531A /* FavoriteListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A0E39B72A10CD4A00DC531A /* FavoriteListViewController.swift */; };
 		6A1CFD332A0D1C29006971AE /* Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1CFD322A0D1C29006971AE /* Preview.swift */; };
 		6A4566BD2A13534C00AE5F62 /* MypagePhotographerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A4566BC2A13534C00AE5F62 /* MypagePhotographerViewController.swift */; };
@@ -72,7 +72,7 @@
 /* Begin PBXFileReference section */
 		6A0E39B12A10CD4200DC531A /* ChattingListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChattingListViewController.swift; sourceTree = "<group>"; };
 		6A0E39B22A10CD4200DC531A /* ChattingListTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChattingListTableViewCell.swift; sourceTree = "<group>"; };
-		6A0E39B62A10CD4A00DC531A /* FavoriteListTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoriteListTableViewCell.swift; sourceTree = "<group>"; };
+		6A0E39B62A10CD4A00DC531A /* BorderedTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BorderedTableViewCell.swift; sourceTree = "<group>"; };
 		6A0E39B72A10CD4A00DC531A /* FavoriteListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoriteListViewController.swift; sourceTree = "<group>"; };
 		6A1CFD322A0D1C29006971AE /* Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preview.swift; sourceTree = "<group>"; };
 		6A4566BC2A13534C00AE5F62 /* MypagePhotographerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypagePhotographerViewController.swift; sourceTree = "<group>"; };
@@ -157,10 +157,17 @@
 		6A0E39B52A10CD4A00DC531A /* FavoriteList */ = {
 			isa = PBXGroup;
 			children = (
-				6A0E39B62A10CD4A00DC531A /* FavoriteListTableViewCell.swift */,
 				6A0E39B72A10CD4A00DC531A /* FavoriteListViewController.swift */,
 			);
 			path = FavoriteList;
+			sourceTree = "<group>";
+		};
+		6A236C222A238D25000CB1E6 /* TableViewCells */ = {
+			isa = PBXGroup;
+			children = (
+				6A0E39B62A10CD4A00DC531A /* BorderedTableViewCell.swift */,
+			);
+			path = TableViewCells;
 			sourceTree = "<group>";
 		};
 		6A4566BE2A13536200AE5F62 /* Mypage */ = {
@@ -207,6 +214,7 @@
 		C766F1592A1097F1009BC30E /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				6A236C222A238D25000CB1E6 /* TableViewCells */,
 				6AA612AC2A176B9700C49095 /* CarouselCollections */,
 				C766F15A2A109806009BC30E /* SnapfitActivityIndicatorView.swift */,
 				6A4CFC102A1893FA00CE5308 /* SnapfitTextView.swift */,
@@ -534,7 +542,7 @@
 				C71730EE2A17427900155D09 /* ReservationViewController.swift in Sources */,
 				C766F17E2A10A47B009BC30E /* Notification+Name+.swift in Sources */,
 				C7E900302A0BC9D600CC620B /* BaseAPI.swift in Sources */,
-				6A0E39B82A10CD4A00DC531A /* FavoriteListTableViewCell.swift in Sources */,
+				6A0E39B82A10CD4A00DC531A /* BorderedTableViewCell.swift in Sources */,
 				6A0E39B42A10CD4200DC531A /* ChattingListTableViewCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SNAPFIT/SNAPFIT.xcodeproj/project.pbxproj
+++ b/SNAPFIT/SNAPFIT.xcodeproj/project.pbxproj
@@ -10,7 +10,7 @@
 		6A013C8B2A08E6EF00DF2FF4 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 6A013C8A2A08E6EF00DF2FF4 /* SnapKit */; };
 		6A0E39B32A10CD4200DC531A /* ChattingListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A0E39B12A10CD4200DC531A /* ChattingListViewController.swift */; };
 		6A0E39B42A10CD4200DC531A /* ChattingListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A0E39B22A10CD4200DC531A /* ChattingListTableViewCell.swift */; };
-		6A0E39B82A10CD4A00DC531A /* HeartListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A0E39B62A10CD4A00DC531A /* HeartListTableViewCell.swift */; };
+		6A0E39B82A10CD4A00DC531A /* FavoriteListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A0E39B62A10CD4A00DC531A /* FavoriteListTableViewCell.swift */; };
 		6A0E39B92A10CD4A00DC531A /* FavoriteListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A0E39B72A10CD4A00DC531A /* FavoriteListViewController.swift */; };
 		6A1CFD332A0D1C29006971AE /* Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1CFD322A0D1C29006971AE /* Preview.swift */; };
 		6A4566BD2A13534C00AE5F62 /* MypagePhotographerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A4566BC2A13534C00AE5F62 /* MypagePhotographerViewController.swift */; };
@@ -72,7 +72,7 @@
 /* Begin PBXFileReference section */
 		6A0E39B12A10CD4200DC531A /* ChattingListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChattingListViewController.swift; sourceTree = "<group>"; };
 		6A0E39B22A10CD4200DC531A /* ChattingListTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChattingListTableViewCell.swift; sourceTree = "<group>"; };
-		6A0E39B62A10CD4A00DC531A /* HeartListTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeartListTableViewCell.swift; sourceTree = "<group>"; };
+		6A0E39B62A10CD4A00DC531A /* FavoriteListTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoriteListTableViewCell.swift; sourceTree = "<group>"; };
 		6A0E39B72A10CD4A00DC531A /* FavoriteListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FavoriteListViewController.swift; sourceTree = "<group>"; };
 		6A1CFD322A0D1C29006971AE /* Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preview.swift; sourceTree = "<group>"; };
 		6A4566BC2A13534C00AE5F62 /* MypagePhotographerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypagePhotographerViewController.swift; sourceTree = "<group>"; };
@@ -157,7 +157,7 @@
 		6A0E39B52A10CD4A00DC531A /* FavoriteList */ = {
 			isa = PBXGroup;
 			children = (
-				6A0E39B62A10CD4A00DC531A /* HeartListTableViewCell.swift */,
+				6A0E39B62A10CD4A00DC531A /* FavoriteListTableViewCell.swift */,
 				6A0E39B72A10CD4A00DC531A /* FavoriteListViewController.swift */,
 			);
 			path = FavoriteList;
@@ -534,7 +534,7 @@
 				C71730EE2A17427900155D09 /* ReservationViewController.swift in Sources */,
 				C766F17E2A10A47B009BC30E /* Notification+Name+.swift in Sources */,
 				C7E900302A0BC9D600CC620B /* BaseAPI.swift in Sources */,
-				6A0E39B82A10CD4A00DC531A /* HeartListTableViewCell.swift in Sources */,
+				6A0E39B82A10CD4A00DC531A /* FavoriteListTableViewCell.swift in Sources */,
 				6A0E39B42A10CD4200DC531A /* ChattingListTableViewCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SNAPFIT/SNAPFIT.xcodeproj/project.pbxproj
+++ b/SNAPFIT/SNAPFIT.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		6A1CFD332A0D1C29006971AE /* Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1CFD322A0D1C29006971AE /* Preview.swift */; };
 		6A4566BD2A13534C00AE5F62 /* MypagePhotographerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A4566BC2A13534C00AE5F62 /* MypagePhotographerViewController.swift */; };
 		6A4CFC112A1893FA00CE5308 /* SnapfitTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A4CFC102A1893FA00CE5308 /* SnapfitTextView.swift */; };
+		6AA54F862A2436B8001E9D2C /* ReservatinDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AA54F852A2436B8001E9D2C /* ReservatinDetailViewController.swift */; };
 		6AA612AE2A176BE200C49095 /* GalleryCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AA612AD2A176BE200C49095 /* GalleryCollectionViewController.swift */; };
 		6AA612B02A17C48B00C49095 /* ReviewCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AA612AF2A17C48B00C49095 /* ReviewCollectionViewController.swift */; };
 		C71730EE2A17427900155D09 /* ReservationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71730ED2A17427900155D09 /* ReservationViewController.swift */; };
@@ -77,6 +78,7 @@
 		6A1CFD322A0D1C29006971AE /* Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preview.swift; sourceTree = "<group>"; };
 		6A4566BC2A13534C00AE5F62 /* MypagePhotographerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypagePhotographerViewController.swift; sourceTree = "<group>"; };
 		6A4CFC102A1893FA00CE5308 /* SnapfitTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapfitTextView.swift; sourceTree = "<group>"; };
+		6AA54F852A2436B8001E9D2C /* ReservatinDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReservatinDetailViewController.swift; sourceTree = "<group>"; };
 		6AA612AD2A176BE200C49095 /* GalleryCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryCollectionViewController.swift; sourceTree = "<group>"; };
 		6AA612AF2A17C48B00C49095 /* ReviewCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewCollectionViewController.swift; sourceTree = "<group>"; };
 		C71730ED2A17427900155D09 /* ReservationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReservationViewController.swift; sourceTree = "<group>"; };
@@ -191,6 +193,7 @@
 			isa = PBXGroup;
 			children = (
 				C71730ED2A17427900155D09 /* ReservationViewController.swift */,
+				6AA54F852A2436B8001E9D2C /* ReservatinDetailViewController.swift */,
 			);
 			path = Reservation;
 			sourceTree = "<group>";
@@ -541,6 +544,7 @@
 				C766F16A2A10A200009BC30E /* UICollectionView+.swift in Sources */,
 				C71730EE2A17427900155D09 /* ReservationViewController.swift in Sources */,
 				C766F17E2A10A47B009BC30E /* Notification+Name+.swift in Sources */,
+				6AA54F862A2436B8001E9D2C /* ReservatinDetailViewController.swift in Sources */,
 				C7E900302A0BC9D600CC620B /* BaseAPI.swift in Sources */,
 				6A0E39B82A10CD4A00DC531A /* BorderedTableViewCell.swift in Sources */,
 				6A0E39B42A10CD4200DC531A /* ChattingListTableViewCell.swift in Sources */,

--- a/SNAPFIT/SNAPFIT/Global/Extensions/UIFont+.swift
+++ b/SNAPFIT/SNAPFIT/Global/Extensions/UIFont+.swift
@@ -8,6 +8,11 @@
 import UIKit
 
 extension UIFont {
+    
+    class var b24: UIFont {
+        return UIFont(name: "Pretendard-Bold", size: 24.0)!
+    }
+    
     class var m24: UIFont {
         return UIFont(name: "Pretendard-Medium", size: 24.0)!
     }

--- a/SNAPFIT/SNAPFIT/Sources/Components/SnapfitNavigationView.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Components/SnapfitNavigationView.swift
@@ -48,7 +48,7 @@ final class SnapfitNavigationView: UIView {
         return imageView
     }()
     
-    private lazy var backButton: UIButton = {
+    lazy var backButton: UIButton = {
         let button: UIButton = UIButton(type: .system)
         button.setImage(UIImage(named: Text.backButtonImageName), for: .normal)
         return button

--- a/SNAPFIT/SNAPFIT/Sources/Components/TableViewCells/BorderedTableViewCell.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Components/TableViewCells/BorderedTableViewCell.swift
@@ -8,7 +8,7 @@
 import UIKit
 import SnapKit
 
-class FavoriteListTableViewCell: UITableViewCell {
+class BorderedTableViewCell: UITableViewCell {
     let picture = UIImageView()
     let title = UILabel()
     

--- a/SNAPFIT/SNAPFIT/Sources/Screens/FavoriteList/FavoriteListTableViewCell.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Screens/FavoriteList/FavoriteListTableViewCell.swift
@@ -8,14 +8,22 @@
 import UIKit
 import SnapKit
 
-class HeartListTableViewCell: UITableViewCell {
+class FavoriteListTableViewCell: UITableViewCell {
     let picture = UIImageView()
     let title = UILabel()
-    let heartButton = UIButton()
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        self.frame.size = CGSize(width: self.frame.width, height: 64)
+        self.accessoryType = .disclosureIndicator
+        self.layer.borderColor = UIColor.sfBlack100.cgColor
+        self.layer.borderWidth = 1
+        self.layer.cornerRadius = 8
+    }
     
     func setPicture() {
-        self.picture.image = UIImage(named: "AppIcon")
-        self.picture.layer.cornerRadius = 25
+        self.picture.backgroundColor = .sfBlack20
+        self.picture.layer.cornerRadius = 20
         self.picture.layer.borderWidth = 1
         self.picture.layer.borderColor = UIColor.clear.cgColor
         self.picture.clipsToBounds = true
@@ -24,27 +32,17 @@ class HeartListTableViewCell: UITableViewCell {
         self.picture.snp.makeConstraints{ make in
             make.centerY.equalToSuperview()
             make.left.equalToSuperview().inset(20)
-            make.height.width.equalTo(50)
+            make.height.width.equalTo(40)
         }
     }
     
     func setTitle(titleText: String) {
         self.title.text = titleText
+        self.title.font = .m13
         self.contentView.addSubview(self.title)
         self.title.snp.makeConstraints{ make in
-            make.left.equalTo(self.picture.snp.right).offset(8)
+            make.left.equalTo(self.picture.snp.right).offset(12)
             make.centerY.equalToSuperview()
-        }
-    }
-
-    func setRightButton() {
-        self.heartButton.setImage(UIImage(systemName: "heart"), for: .normal)
-        self.heartButton.setImage(UIImage(systemName: "heart.fill"), for: .selected)
-        self.heartButton.tintColor = .sfMainRed
-        self.contentView.addSubview(self.heartButton)
-        self.heartButton.snp.makeConstraints{ make in
-            make.centerY.equalToSuperview()
-            make.right.equalToSuperview().inset(20)
         }
     }
     

--- a/SNAPFIT/SNAPFIT/Sources/Screens/FavoriteList/FavoriteListViewController.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Screens/FavoriteList/FavoriteListViewController.swift
@@ -8,26 +8,44 @@
 import UIKit
 
 class FavoriteListViewController: BaseViewController {
-    let favoriteListTableView = UITableView()
+    let titleLabel: UILabel = {
+        let titleLabel: UILabel = UILabel()
+        titleLabel.text = "관심 목록"
+        titleLabel.font = .b24
+        return titleLabel
+    }()
+    let favoriteListTableView: UITableView = {
+        let favoriteListTableView: UITableView = UITableView()
+        favoriteListTableView.backgroundColor = .clear
+        favoriteListTableView.separatorStyle = .none
+        favoriteListTableView.showsVerticalScrollIndicator = false
+        favoriteListTableView.register(BorderedTableViewCell.self, forCellReuseIdentifier: "favoriteListTableViewCell")
+        return favoriteListTableView
+    }()
     
     // MARK: - View LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        self.setLayout()
+        self.setTitleLayout()
+        self.setTableView()
     }
     
-    private func setLayout() {
-        self.view.backgroundColor = .sfGrayWhite
-        self.favoriteListTableView.backgroundColor = .clear
-        self.favoriteListTableView.separatorStyle = .none
-        self.favoriteListTableView.showsVerticalScrollIndicator = false
+    // MARK: - Method
+    private func setTitleLayout() {
+        self.view.addSubview(self.titleLabel)
+        self.titleLabel.snp.makeConstraints{ make in
+            make.top.equalTo(92)
+            make.left.right.equalToSuperview().inset(20)
+        }
+    }
+    
+    private func setTableView() {
         self.favoriteListTableView.delegate = self
         self.favoriteListTableView.dataSource = self
-        self.favoriteListTableView.register(BorderedTableViewCell.self, forCellReuseIdentifier: "favoriteListTableViewCell")
         view.addSubview(favoriteListTableView)
         favoriteListTableView.snp.makeConstraints{ make in
-            make.top.bottom.equalToSuperview()
+            make.top.equalTo(self.titleLabel.snp.bottom).offset(16)
+            make.bottom.equalToSuperview()
             make.left.right.equalToSuperview().inset(20)
         }
     }

--- a/SNAPFIT/SNAPFIT/Sources/Screens/FavoriteList/FavoriteListViewController.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Screens/FavoriteList/FavoriteListViewController.swift
@@ -7,22 +7,28 @@
 
 import UIKit
 
-class FavoriteListViewController: UIViewController {
-    let heartListTableView = UITableView()
+class FavoriteListViewController: BaseViewController {
+    let favoriteListTableView = UITableView()
+    
+    // MARK: - View LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        heartListTableView.separatorStyle = .singleLine
-        heartListTableView.delegate = self
-        heartListTableView.dataSource = self
-        heartListTableView.register(HeartListTableViewCell.self, forCellReuseIdentifier: "heartListTableViewCell")
-        view.addSubview(heartListTableView)
-        heartListTableView.snp.makeConstraints{ make in
-            make.edges.equalToSuperview()
+        self.view.backgroundColor = .sfGrayWhite
+        self.favoriteListTableView.backgroundColor = .clear
+        self.favoriteListTableView.separatorStyle = .none
+        self.favoriteListTableView.showsVerticalScrollIndicator = false
+        self.favoriteListTableView.delegate = self
+        self.favoriteListTableView.dataSource = self
+        self.favoriteListTableView.register(FavoriteListTableViewCell.self, forCellReuseIdentifier: "favoriteListTableViewCell")
+        view.addSubview(favoriteListTableView)
+        favoriteListTableView.snp.makeConstraints{ make in
+            make.top.bottom.equalToSuperview()
+            make.left.right.equalToSuperview().inset(20)
         }
     }
 }
 
+// MARK: - Extensions
 extension FavoriteListViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         82
@@ -37,10 +43,9 @@ extension FavoriteListViewController: UITableViewDataSource {
         20
     }
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "heartListTableViewCell") as! HeartListTableViewCell
+        let cell = tableView.dequeueReusableCell(withIdentifier: "favoriteListTableViewCell") as! FavoriteListTableViewCell
         cell.setPicture()
-        cell.setTitle(titleText: "닉네임\(indexPath.row)")
-        cell.setRightButton()
+        cell.setTitle(titleText: "닉네임열글자까지\(indexPath.row)")
         return cell
     }
 }

--- a/SNAPFIT/SNAPFIT/Sources/Screens/FavoriteList/FavoriteListViewController.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Screens/FavoriteList/FavoriteListViewController.swift
@@ -13,13 +13,18 @@ class FavoriteListViewController: BaseViewController {
     // MARK: - View LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        self.setLayout()
+    }
+    
+    private func setLayout() {
         self.view.backgroundColor = .sfGrayWhite
         self.favoriteListTableView.backgroundColor = .clear
         self.favoriteListTableView.separatorStyle = .none
         self.favoriteListTableView.showsVerticalScrollIndicator = false
         self.favoriteListTableView.delegate = self
         self.favoriteListTableView.dataSource = self
-        self.favoriteListTableView.register(FavoriteListTableViewCell.self, forCellReuseIdentifier: "favoriteListTableViewCell")
+        self.favoriteListTableView.register(BorderedTableViewCell.self, forCellReuseIdentifier: "favoriteListTableViewCell")
         view.addSubview(favoriteListTableView)
         favoriteListTableView.snp.makeConstraints{ make in
             make.top.bottom.equalToSuperview()
@@ -43,7 +48,7 @@ extension FavoriteListViewController: UITableViewDataSource {
         20
     }
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "favoriteListTableViewCell") as! FavoriteListTableViewCell
+        let cell = tableView.dequeueReusableCell(withIdentifier: "favoriteListTableViewCell") as! BorderedTableViewCell
         cell.setPicture()
         cell.setTitle(titleText: "닉네임열글자까지\(indexPath.row)")
         return cell

--- a/SNAPFIT/SNAPFIT/Sources/Screens/Reservation/ReservatinDetailViewController.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Screens/Reservation/ReservatinDetailViewController.swift
@@ -8,28 +8,30 @@
 import UIKit
 
 class ReservationDetailViewController: BaseViewController {
+    // MARK: - Properties
     private let navigationView: SnapfitNavigationView = {
-        let view: SnapfitNavigationView = SnapfitNavigationView(type: .close)
+        let view: SnapfitNavigationView = SnapfitNavigationView(type: .backTitle)
         view.setTitle("예약 확인")
         return view
     }()
     
+    // MARK: - View LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
         self.setLayout()
     }
     
+    // MARK: - Methods
     private func setLayout() {
         self.view.addSubviews([navigationView])
-        self.setNavigationbar()
+        self.setNavigationView()
         self.navigationView.snp.makeConstraints { make in
             make.top.horizontalEdges.equalTo(self.view.safeAreaLayoutGuide)
         }
     }
     
-    private func setNavigationbar() {
-        // TODO: navigationView 고치고 backButton으로 수정 필요
-        self.navigationView.closeButton.setAction {
+    private func setNavigationView() {
+        self.navigationView.backButton.setAction {
             self.dismiss(animated: true)
         }
     }

--- a/SNAPFIT/SNAPFIT/Sources/Screens/Reservation/ReservatinDetailViewController.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Screens/Reservation/ReservatinDetailViewController.swift
@@ -1,0 +1,36 @@
+//
+//  ReservatinDetailViewController.swift
+//  SNAPFIT
+//
+//  Created by 강유진 on 2023/05/29.
+//
+
+import UIKit
+
+class ReservationDetailViewController: BaseViewController {
+    private let navigationView: SnapfitNavigationView = {
+        let view: SnapfitNavigationView = SnapfitNavigationView(type: .close)
+        view.setTitle("예약 확인")
+        return view
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.setLayout()
+    }
+    
+    private func setLayout() {
+        self.view.addSubviews([navigationView])
+        self.setNavigationbar()
+        self.navigationView.snp.makeConstraints { make in
+            make.top.horizontalEdges.equalTo(self.view.safeAreaLayoutGuide)
+        }
+    }
+    
+    private func setNavigationbar() {
+        // TODO: navigationView 고치고 backButton으로 수정 필요
+        self.navigationView.closeButton.setAction {
+            self.dismiss(animated: true)
+        }
+    }
+}

--- a/SNAPFIT/SNAPFIT/Sources/Screens/Reservation/ReservationViewController.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Screens/Reservation/ReservationViewController.swift
@@ -8,10 +8,49 @@
 import UIKit
 
 final class ReservationViewController: BaseViewController {
+    let reservationTableView = UITableView()
     
-    // MARK: View Life Cycle
-    
+    // MARK: - View LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        self.setLayout()
+    }
+    
+    private func setLayout() {
+        self.view.backgroundColor = .sfGrayWhite
+        self.reservationTableView.backgroundColor = .clear
+        self.reservationTableView.separatorStyle = .none
+        self.reservationTableView.showsVerticalScrollIndicator = false
+        self.reservationTableView.delegate = self
+        self.reservationTableView.dataSource = self
+        self.reservationTableView.register(BorderedTableViewCell.self, forCellReuseIdentifier: "reservationTableViewCell")
+        view.addSubview(reservationTableView)
+        reservationTableView.snp.makeConstraints{ make in
+            make.top.bottom.equalToSuperview()
+            make.left.right.equalToSuperview().inset(20)
+        }
+    }
+}
+
+// MARK: - Extensions
+extension ReservationViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        82
+    }
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        // TODO: 셀 선택 시 동작 구현
+    }
+}
+
+extension ReservationViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        7
+    }
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "reservationTableViewCell") as! BorderedTableViewCell
+        cell.setPicture()
+        cell.setTitle(titleText: "여기도닉네임이\(indexPath.row)")
+        return cell
     }
 }

--- a/SNAPFIT/SNAPFIT/Sources/Screens/Reservation/ReservationViewController.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Screens/Reservation/ReservationViewController.swift
@@ -8,26 +8,44 @@
 import UIKit
 
 final class ReservationViewController: BaseViewController {
-    let reservationTableView = UITableView()
+    let titleLabel: UILabel = {
+        let titleLabel: UILabel = UILabel()
+        titleLabel.text = "예약 관리"
+        titleLabel.font = .b24
+        return titleLabel
+    }()
+    let reservationTableView: UITableView = {
+        let reservationTableView: UITableView = UITableView()
+            reservationTableView.backgroundColor = .clear
+            reservationTableView.separatorStyle = .none
+            reservationTableView.showsVerticalScrollIndicator = false
+            reservationTableView.register(BorderedTableViewCell.self, forCellReuseIdentifier: "reservationTableViewCell")
+        return reservationTableView
+    }()
     
     // MARK: - View LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        self.setLayout()
+        self.setTitleLayout()
+        self.setTableView()
     }
     
-    private func setLayout() {
-        self.view.backgroundColor = .sfGrayWhite
-        self.reservationTableView.backgroundColor = .clear
-        self.reservationTableView.separatorStyle = .none
-        self.reservationTableView.showsVerticalScrollIndicator = false
+    // MARK: - Method    
+    private func setTitleLayout() {
+        self.view.addSubview(self.titleLabel)
+        self.titleLabel.snp.makeConstraints{ make in
+            make.top.equalTo(92)
+            make.left.right.equalToSuperview().inset(20)
+        }
+    }
+    
+    private func setTableView() {
         self.reservationTableView.delegate = self
         self.reservationTableView.dataSource = self
-        self.reservationTableView.register(BorderedTableViewCell.self, forCellReuseIdentifier: "reservationTableViewCell")
-        view.addSubview(reservationTableView)
-        reservationTableView.snp.makeConstraints{ make in
-            make.top.bottom.equalToSuperview()
+        self.view.addSubview(reservationTableView)
+        self.reservationTableView.snp.makeConstraints{ make in
+            make.top.equalTo(self.titleLabel.snp.bottom).offset(16)
+            make.bottom.equalToSuperview()
             make.left.right.equalToSuperview().inset(20)
         }
     }
@@ -40,12 +58,15 @@ extension ReservationViewController: UITableViewDelegate {
     }
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         // TODO: 셀 선택 시 동작 구현
+        lazy var detailView: ReservationDetailViewController = ReservationDetailViewController()
+        detailView.modalPresentationStyle = .fullScreen
+        self.present(detailView, animated: true)
     }
 }
 
 extension ReservationViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        7
+        11
     }
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "reservationTableViewCell") as! BorderedTableViewCell


### PR DESCRIPTION
## 작업한 내용
- 신규 디자인으로 관심 목록, 예약관리 테이블 셀 수정
- 각 뷰에 네비게이션 연결
- 탭뷰에 연결
- 예약확인 뷰 생성 및 연결


## PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 예약확인 뷰는 뷰만 만들었고 새로 브랜치 파서 디자인 적용할 예정!


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->

<img width="396" alt="image" src="https://github.com/2023-SWU-Snapfit/SNAPFIT-iOS/assets/86394389/f4e050eb-a49f-458f-b378-61151bc8dd91">


## 관련 이슈
- Resolved: #24


<!-- Assignee, Reviewer 설정! 😇 -->
