### PR TITLE
Feat/#42 r마이페이지-프로필 서버 통신 함수 설정

### DIFF
--- a/SNAPFIT/SNAPFIT.xcodeproj/project.pbxproj
+++ b/SNAPFIT/SNAPFIT.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		6AD458542A94B47F001D90A2 /* ReviewDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD458532A94B47F001D90A2 /* ReviewDetailViewController.swift */; };
 		6AD589942A67EC42009C7A3C /* Reservations.json in Resources */ = {isa = PBXBuildFile; fileRef = 6AD589932A67EC41009C7A3C /* Reservations.json */; };
 		6AD589962A6811C9009C7A3C /* DateDataDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AD589952A6811C9009C7A3C /* DateDataDelegate.swift */; };
+		6AE4FC862B0F9B290057C660 /* UserDataMethodManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AE4FC852B0F9B290057C660 /* UserDataMethodManager.swift */; };
 		6AEC75452ADE9A41004847DA /* UserListResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AEC75442ADE9A41004847DA /* UserListResponseDTO.swift */; };
 		6AEC75482ADE9B18004847DA /* UserDetailResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AEC75472ADE9B18004847DA /* UserDetailResponseDTO.swift */; };
 		6AF625492A5D1AC200B6FF9E /* ReservationTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AF625482A5D1AC200B6FF9E /* ReservationTableViewCell.swift */; };
@@ -194,6 +195,7 @@
 		6AD458532A94B47F001D90A2 /* ReviewDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDetailViewController.swift; sourceTree = "<group>"; };
 		6AD589932A67EC41009C7A3C /* Reservations.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Reservations.json; sourceTree = "<group>"; };
 		6AD589952A6811C9009C7A3C /* DateDataDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateDataDelegate.swift; sourceTree = "<group>"; };
+		6AE4FC852B0F9B290057C660 /* UserDataMethodManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDataMethodManager.swift; sourceTree = "<group>"; };
 		6AEC75442ADE9A41004847DA /* UserListResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserListResponseDTO.swift; sourceTree = "<group>"; };
 		6AEC75472ADE9B18004847DA /* UserDetailResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDetailResponseDTO.swift; sourceTree = "<group>"; };
 		6AF625482A5D1AC200B6FF9E /* ReservationTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReservationTableViewCell.swift; sourceTree = "<group>"; };
@@ -378,8 +380,8 @@
 			isa = PBXGroup;
 			children = (
 				6A4566BC2A13534C00AE5F62 /* MypagePhotographerViewController.swift */,
-				6A3FA4C02A2C1099000382CF /* MypageGeneralUserViewController.swift */,
 				6A8566592A99D97300F66321 /* MypagePhotographerEditingViewController.swift */,
+				6A3FA4C02A2C1099000382CF /* MypageGeneralUserViewController.swift */,
 				6A85665B2A99D98900F66321 /* MypageGeneralUserEditingViewController.swift */,
 				6A2D0BB62A9D7CC900B3E123 /* SettingViewController.swift */,
 				6AA3236C2A9F19F20005453E /* SettingContactTableViewCell.swift */,
@@ -436,6 +438,14 @@
 				6AB807632AD14F3F00FAF8BE /* ReservationDetailResponseDTO.swift */,
 			);
 			path = Response;
+			sourceTree = "<group>";
+		};
+		6AE4FC842B0F9B030057C660 /* DatMethodManager */ = {
+			isa = PBXGroup;
+			children = (
+				6AE4FC852B0F9B290057C660 /* UserDataMethodManager.swift */,
+			);
+			path = DatMethodManager;
 			sourceTree = "<group>";
 		};
 		6AEC75462ADE9A63004847DA /* Request */ = {
@@ -501,6 +511,7 @@
 		C766F1592A1097F1009BC30E /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				6AE4FC842B0F9B030057C660 /* DatMethodManager */,
 				6A236C222A238D25000CB1E6 /* TableViewCells */,
 				6AA612AC2A176B9700C49095 /* CarouselCollections */,
 				C766F15A2A109806009BC30E /* SnapfitActivityIndicatorView.swift */,
@@ -952,6 +963,7 @@
 				6A3F09522AA344B300C51179 /* ReviewRouter.swift in Sources */,
 				6A04FE8A2A20CD5100FADEC8 /* SnapfitUserInformationViewController.swift in Sources */,
 				FF2E86A32AA20C0600258D75 /* SnapfitMoyaProvider.swift in Sources */,
+				6AE4FC862B0F9B290057C660 /* UserDataMethodManager.swift in Sources */,
 				C766F1602A109AAB009BC30E /* ClassName.swift in Sources */,
 				FF2E86A12AA20BCE00258D75 /* BaseResponseType.swift in Sources */,
 				6A3F09542AA3475300C51179 /* ReviewService.swift in Sources */,

--- a/SNAPFIT/SNAPFIT/Global/Singletons/UserInfo.swift
+++ b/SNAPFIT/SNAPFIT/Global/Singletons/UserInfo.swift
@@ -13,5 +13,6 @@ class UserInfo {
     init() { }
     
     var userID: Int = -1
+    var userPosition: String = ""
     var accessToken: String = ""
 }

--- a/SNAPFIT/SNAPFIT/Network/DTO/User/Response/UserDetailResponseDTO.swift
+++ b/SNAPFIT/SNAPFIT/Network/DTO/User/Response/UserDetailResponseDTO.swift
@@ -22,8 +22,8 @@ struct UserDetailResponseDTOElement: Codable {
     let email: String
     let info: String?
     let gallery: [Gallery]
-    let averageStars: Float
-    let review: [ReviewListResponseDTOElement]
+    let averageStars: Float?
+    let review: [UserReviewList]
     let cost: String?
     
     enum CodingKeys: String, CodingKey {
@@ -61,6 +61,18 @@ struct Gallery: Codable {
         case isDeleted = "isDeleted"
         case tag = "tag"
         case isPinned = "isPinned"
+    }
+}
+
+struct UserReviewList: Codable {
+    let id: Int
+    let star: Int
+    let photoUrl: String
+    
+    enum CodingKeys: String, CodingKey {
+        case id = "id"
+        case star = "star"
+        case photoUrl = "photoUrl"
     }
 }
 

--- a/SNAPFIT/SNAPFIT/Sources/Components/CarouselCollections/ReviewCollectionViewController.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Components/CarouselCollections/ReviewCollectionViewController.swift
@@ -11,8 +11,9 @@ import SnapKit
 class ReviewCollectionViewController: UIViewController {
     
     // MARK: - Properties
+    private var avgStars: Float = 0.0
     private var numOfItems: Int = 0
-    private var reviews: [Review] = []
+    private var reviews: [UserReviewList] = []
     var reviewDataDelegate: ReviewDataDelegate?
     
     // MARK: - UI Components
@@ -34,22 +35,22 @@ class ReviewCollectionViewController: UIViewController {
         super.viewDidLoad()
         self.setCollection()
         self.setComponents()
+        print("😉 \(self.numOfItems)")
     }
     
+    
+    
     // MARK: - Methods
-    public func setReview(reviews: [Review]) {
+    public func setReview(reviews: [UserReviewList], avgStars: Float) {
         self.numOfItems = reviews.count
         self.reviews = reviews
-        self.titleLabel.text = "리뷰(★ \(String(format: "%.1f", self.avgScore())))"
+        self.avgStars = avgStars
+        self.titleLabel.text = "리뷰(★ \(String(format: "%.1f", self.avgStars)))"
+        self.collectionView.reloadData()
     }
     
     public func setDelegate(_ receiver: SnapfitUserInformationViewController) {
         self.reviewDataDelegate = receiver
-    }
-    
-    private func avgScore() -> Double {
-        let scores = self.reviews.map { $0.score }
-        return Double(scores.reduce(0,+))/Double(scores.count)
     }
     
     private func setCollection() {
@@ -59,7 +60,7 @@ class ReviewCollectionViewController: UIViewController {
     }
     
     private func setComponents() {
-        self.titleLabel.text = "리뷰(★ \(String(format: "%.1f", self.avgScore())))"
+        self.titleLabel.text = "리뷰(★ \(String(format: "%.1f", self.avgStars)))"
         self.titleLabel.font = .b18
         
         self.view.addSubview(self.titleLabel)
@@ -77,7 +78,8 @@ class ReviewCollectionViewController: UIViewController {
 
 extension ReviewCollectionViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        self.reviewDataDelegate?.sendReview(data: self.reviews[indexPath.row])
+        // TODO: [REVIEW] 리뷰 상세보기로 연결하기
+//        self.reviewDataDelegate?.sendReview(data: self.reviews[indexPath.row])
     }
 }
 
@@ -98,17 +100,15 @@ extension ReviewCollectionViewController: UICollectionViewDataSource {
         cell.makeRounded(cornerRadius: 8)
         
         reviewImage.backgroundColor = .sfBlack40
-        if let newImage = reviews[indexPath.row].image {
-            reviewImage.image = newImage
-        }
+        reviewImage.setImageUrl(self.reviews[indexPath.row].photoUrl)
         reviewImage.contentMode = .scaleAspectFill
         reviewImage.makeRounded(cornerRadius: 8)
         
-        score.text = "★ \(reviews[indexPath.row].score)"
+        score.text = "★ \(reviews[indexPath.row].star)"
         score.textColor = .sfMainRed
         score.font = .m13
         
-        reviewDetails.text = self.reviews[indexPath.row].contentText
+        reviewDetails.text = "\(self.reviews[indexPath.row])"
         reviewDetails.font = .m13
         reviewDetails.textColor = .sfBlack100
         reviewDetails.isScrollEnabled = false

--- a/SNAPFIT/SNAPFIT/Sources/Components/CarouselCollections/ReviewCollectionViewController.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Components/CarouselCollections/ReviewCollectionViewController.swift
@@ -21,7 +21,7 @@ class ReviewCollectionViewController: UIViewController {
     let collectionView : UICollectionView = {
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.sectionInset = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
-        flowLayout.itemSize = CGSize(width: 126, height: 172)
+        flowLayout.itemSize = CGSize(width: 126, height: 98)
         flowLayout.minimumLineSpacing = 8
         flowLayout.scrollDirection = .horizontal
         let collectionView = UICollectionView(frame: .init(x: 0, y: 0, width: 10, height: 10), collectionViewLayout: flowLayout)
@@ -35,7 +35,6 @@ class ReviewCollectionViewController: UIViewController {
         super.viewDidLoad()
         self.setCollection()
         self.setComponents()
-        print("😉 \(self.numOfItems)")
     }
     
     
@@ -108,16 +107,6 @@ extension ReviewCollectionViewController: UICollectionViewDataSource {
         score.textColor = .sfMainRed
         score.font = .m13
         
-        reviewDetails.text = "\(self.reviews[indexPath.row])"
-        reviewDetails.font = .m13
-        reviewDetails.textColor = .sfBlack100
-        reviewDetails.isScrollEnabled = false
-        reviewDetails.isEditable = false
-        reviewDetails.isSelectable = false
-        reviewDetails.textContainerInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
-        reviewDetails.textContainer.maximumNumberOfLines = 3
-        reviewDetails.textContainer.lineBreakMode = .byTruncatingTail
-        
         cell.addSubview(reviewImage)
         reviewImage.snp.makeConstraints{ make in
             make.top.left.equalTo(8)
@@ -129,13 +118,6 @@ extension ReviewCollectionViewController: UICollectionViewDataSource {
             make.top.equalTo(reviewImage.snp.bottom).offset(8)
             make.left.equalTo(8)
             make.height.equalTo(20)
-        }
-        cell.addSubview(reviewDetails)
-        reviewDetails.snp.makeConstraints{ make in
-            make.top.equalTo(score.snp.bottom)
-            make.left.equalTo(score)
-            make.width.equalTo(reviewImage.snp.width)
-            make.bottom.equalToSuperview().inset(8)
         }
         return cell
     }

--- a/SNAPFIT/SNAPFIT/Sources/Components/CarouselCollections/UserGalleryCollectionViewController.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Components/CarouselCollections/UserGalleryCollectionViewController.swift
@@ -12,7 +12,7 @@ class UserGalleryCollectionViewController: UIViewController {
     
     // MARK: - Properties
     private var numOfItems: Int = 0
-    private var images: [UIImage] = []
+    private var gallaryData: [Gallery] = []
     
     // MARK: - UIComponents
     let titleLabel: UILabel = {
@@ -57,9 +57,9 @@ class UserGalleryCollectionViewController: UIViewController {
     
     // MARK: - Methods
     
-    public func setGallery(galleryImages: [UIImage]) {
-        self.numOfItems = galleryImages.count
-        self.images = galleryImages
+    public func setGallery(gallery: [Gallery]) {
+        self.numOfItems = gallery.count
+        self.gallaryData = gallery
     }
     
     func setLayout() {
@@ -94,7 +94,8 @@ extension UserGalleryCollectionViewController: UICollectionViewDataSource {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "galleryCell", for: indexPath)
         cell.backgroundColor = .sfBlack40
         cell.makeRounded(cornerRadius: 8)
-        let imageView: UIImageView = UIImageView(image: images[indexPath.row])
+        let imageView: UIImageView = UIImageView()
+        imageView.setImageUrl(self.gallaryData[indexPath.row].photoUrl)
         imageView.contentMode = .scaleAspectFill
         cell.addSubview(imageView)
         imageView.snp.makeConstraints{ make in

--- a/SNAPFIT/SNAPFIT/Sources/Components/CarouselCollections/UserGalleryCollectionViewController.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Components/CarouselCollections/UserGalleryCollectionViewController.swift
@@ -60,6 +60,7 @@ class UserGalleryCollectionViewController: UIViewController {
     public func setGallery(gallery: [Gallery]) {
         self.numOfItems = gallery.count
         self.gallaryData = gallery
+        self.collectionView.reloadData()
     }
     
     func setLayout() {

--- a/SNAPFIT/SNAPFIT/Sources/Components/DatMethodManager/UserDataMethodManager.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Components/DatMethodManager/UserDataMethodManager.swift
@@ -1,0 +1,43 @@
+//
+//  UserDataMethodManager.swift
+//  SNAPFIT
+//
+//  Created by 강유진 on 2023/11/23.
+//
+
+import Foundation
+
+enum UserPosition: String {
+    case general = "GENERAL"
+    case photographer = "PHOTOGRAPHER"
+}
+
+func getMyUserPosition() -> String {
+    var positionData: String = ""
+    getMyUserData { result in
+        positionData = result.position
+        print("There is the \(positionData)")
+    }
+    print("Here is the \(positionData)")
+    return positionData
+}
+
+func getMyUserData(completion: @escaping(UserDetailResponseDTO) -> ()) {
+    UserService.shared.getUserDetail(targetId: 11) { networkResult in
+        print(networkResult)
+        switch networkResult {
+        case .success(let responseData):
+            if let result = responseData as? UserDetailResponseDTO {
+                completion(result)
+            }
+        case .requestErr(_):
+            print("requestError")
+        case .pathErr:
+            print("pathErr")
+        case .serverErr:
+            print("serverErr")
+        case .networkFail:
+            print("networkErr")
+        }
+    }
+}

--- a/SNAPFIT/SNAPFIT/Sources/Components/DatMethodManager/UserDataMethodManager.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Components/DatMethodManager/UserDataMethodManager.swift
@@ -23,8 +23,26 @@ func getMyUserPosition() -> String {
 }
 
 func getMyUserData(completion: @escaping(UserDetailResponseDTO) -> ()) {
-    UserService.shared.getUserDetail(targetId: 11) { networkResult in
-        print(networkResult)
+    UserService.shared.getUserDetail(targetId: UserInfo.shared.userID) { networkResult in
+        switch networkResult {
+        case .success(let responseData):
+            if let result = responseData as? UserDetailResponseDTO {
+                completion(result)
+            }
+        case .requestErr(_):
+            print("requestError")
+        case .pathErr:
+            print("pathErr")
+        case .serverErr:
+            print("serverErr")
+        case .networkFail:
+            print("networkErr")
+        }
+    }
+}
+
+func getUserData(targetID: Int, completion: @escaping(UserDetailResponseDTO) -> ()) {
+    UserService.shared.getUserDetail(targetId: targetID) { networkResult in
         switch networkResult {
         case .success(let responseData):
             if let result = responseData as? UserDetailResponseDTO {

--- a/SNAPFIT/SNAPFIT/Sources/Components/SnapfitTabBarController.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Components/SnapfitTabBarController.swift
@@ -72,12 +72,12 @@ final class SnapfitTabBarController: UITabBarController, UITabBarControllerDeleg
         reservationTab.tabBarItem.tag = 2
         
         let mypageTab: UIViewController = self.makeTabVC(
-            vc: BaseNavigationController(rootViewController: MypagePhotographerViewController()), // TODO: 마이페이지 vc 넣기
+            vc: BaseNavigationController(rootViewController: UserInfo.shared.userPosition == UserPosition.general.rawValue ? MypageGeneralUserViewController() :  MypagePhotographerViewController()),
             tabBarTitle: Text.mypageTitle,
             tabBarImg: Text.mypageIconName,
             tabBarSelectedImg: Text.mypageIconName + Text.selected
         )
-        reservationTab.tabBarItem.tag = 3
+        mypageTab.tabBarItem.tag = 3
         
         let tabs = [homeTab, favoriteListTab, reservationTab, mypageTab]
         self.setViewControllers(tabs, animated: true)

--- a/SNAPFIT/SNAPFIT/Sources/Components/SnapfitUserInformationViewController.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Components/SnapfitUserInformationViewController.swift
@@ -24,6 +24,7 @@ class SnapfitUserInformationViewController: BaseViewController {
     // MARK: - Properties
     private var isPhotographer: Bool = false
     private var isApproved: Bool = false
+    private var padding: CGFloat = 0
     
     // MARK: - UIComponents
     private let scrollView: UIScrollView = {
@@ -113,6 +114,10 @@ class SnapfitUserInformationViewController: BaseViewController {
         let introduceTextView: SnapfitTextView = SnapfitTextView(isEditable: false)
         return introduceTextView
     }()
+    private let gptTextView: SnapfitTextView = {
+        let gptTextView: SnapfitTextView = SnapfitTextView(isEditable:  false)
+        return gptTextView
+    }()
     private let galleryCarouselViewController: UserGalleryCollectionViewController = UserGalleryCollectionViewController()
     private let reviewCarouselViewController: ReviewCollectionViewController = ReviewCollectionViewController()
     private let possibleDateTitleLabel: UILabel = {
@@ -178,15 +183,15 @@ class SnapfitUserInformationViewController: BaseViewController {
         self.priceTextView.setText(text: text)
     }
     
-    public func setProfileImage(profileImage: UIImage?) {
+    public func setProfileImage(profileImage: String?) {
         if let newImage = profileImage {
-            self.profileImageView.image = newImage
+            self.profileImageView.setImageUrl(newImage)
         }
     }
     
-    public func setBannerImage(bannerImage: UIImage?) {
+    public func setBannerImage(bannerImage: String?) {
         if let newImage = bannerImage {
-            self.bannerImageView.image = newImage
+            self.bannerImageView.setImageUrl(newImage)
         }
     }
     
@@ -195,6 +200,12 @@ class SnapfitUserInformationViewController: BaseViewController {
         self.setNickname(text: nicknameText)
         self.setInstagramText(text: instagramText)
     }
+    
+    public func setGptData(gptReview: String) {
+        self.gptTextView.text = gptReview
+        self.setGptTextViewLayout()
+    }
+    
     public func setGalleryAndReviewData(gallery: [Gallery], reviews: [UserReviewList], avgStars: Float) {
         self.galleryCarouselViewController.setGallery(gallery: gallery)
         self.reviewCarouselViewController.setReview(reviews: reviews, avgStars: avgStars)
@@ -336,17 +347,27 @@ extension SnapfitUserInformationViewController {
         self.mailSignImageView.isHidden = self.mailLabel.text == "" ? true : false
     }
     
+    private func setGptTextViewLayout() {
+        self.view.addSubview(self.gptTextView)
+        self.gptTextView.snp.makeConstraints { make in
+            make.top.equalTo(introduceTextView.snp.bottom).offset(24)
+            make.left.equalTo(20)
+            make.width.equalToSuperview().inset(20)
+        }
+        self.padding = self.gptTextView.bounds.height + 24
+    }
+    
     private func setGalleryAndReviewLayout(isPhotographer: Bool) {
         self.contentView.addSubview(self.galleryCarouselViewController.view)
         self.galleryCarouselViewController.view.snp.makeConstraints{ make in
-            make.top.equalTo(introduceTextView.snp.bottom).offset(24)
+            make.top.equalTo(introduceTextView.snp.bottom).offset(24 + padding)
             make.left.right.width.equalToSuperview()
             make.height.equalTo(175)
         }
         self.contentView.addSubview(self.reviewCarouselViewController.view)
         self.reviewCarouselViewController.view.snp.makeConstraints{ make in
             make.top.equalTo(galleryCarouselViewController.view.snp.bottom).offset(24)
-            make.height.equalTo(214)
+            make.height.equalTo(144)
             make.left.right.width.equalToSuperview()
             if !isPhotographer {
                 make.bottom.equalToSuperview()
@@ -354,43 +375,43 @@ extension SnapfitUserInformationViewController {
         }
     }
     
-    private func setPossibleDateAndPrice() {
+    func setPossibleDateAndPrice() {
         self.contentView.addSubview(self.possibleDateTitleLabel)
         self.possibleDateTitleLabel.snp.makeConstraints{ make in
-            make.top.equalTo(self.reviewCarouselViewController.view.snp.bottom).offset(24)
+            make.top.equalTo(self.reviewCarouselViewController.view.snp.bottom).offset(24 + padding)
             make.left.equalTo(20)
         }
         self.contentView.addSubview(self.possibleDateTextView)
         self.possibleDateTextView.snp.makeConstraints{ make in
-            make.top.equalTo(self.possibleDateTitleLabel.snp.bottom).offset(16)
+            make.top.equalTo(self.possibleDateTitleLabel.snp.bottom).offset(16 + padding)
             make.left.equalTo(20)
             make.width.equalToSuperview().inset(20)
         }
         self.contentView.addSubview(self.priceTitleLabel)
         self.priceTitleLabel.snp.makeConstraints{ make in
-            make.top.equalTo(self.possibleDateTextView.snp.bottom).offset(24)
+            make.top.equalTo(self.possibleDateTextView.snp.bottom).offset(24 + padding)
             make.left.equalTo(20)
         }
         self.contentView.addSubview(self.priceTextView)
         self.priceTextView.snp.makeConstraints{ make in
-            make.top.equalTo(priceTitleLabel.snp.bottom).offset(16)
+            make.top.equalTo(priceTitleLabel.snp.bottom).offset(16 + padding)
             make.left.equalTo(20)
             make.width.bottom.equalToSuperview().inset(20)
         }
         if self.possibleDateTextView.text == "" {
             self.possibleDateTitleLabel.isHidden = true
             self.possibleDateTextView.snp.makeConstraints{ make in
-                make.top.equalTo(self.reviewCarouselViewController.view.snp.bottom)
+                make.top.equalTo(self.reviewCarouselViewController.view.snp.bottom).offset(padding)
             }
             self.priceTitleLabel.snp.makeConstraints{ make in
-                make.top.equalTo(self.reviewCarouselViewController.view.snp.bottom).offset(24)
+                make.top.equalTo(self.reviewCarouselViewController.view.snp.bottom).offset(24 + padding)
                 make.left.equalTo(20)
             }
         }
         if self.priceTextView.text == "" {
             self.priceTitleLabel.isHidden = true
             self.priceTextView.snp.makeConstraints{ make in
-                make.top.equalTo(self.possibleDateTextView.snp.bottom)
+                make.top.equalTo(self.possibleDateTextView.snp.bottom).offset(padding)
                 make.width.bottom.equalToSuperview().inset(20)
             }
         }

--- a/SNAPFIT/SNAPFIT/Sources/Components/SnapfitUserInformationViewController.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Components/SnapfitUserInformationViewController.swift
@@ -195,9 +195,9 @@ class SnapfitUserInformationViewController: BaseViewController {
         self.setNickname(text: nicknameText)
         self.setInstagramText(text: instagramText)
     }
-    public func setGalleryAndReviewData(galleryImages: [UIImage], reviews: [Review]) {
-        self.galleryCarouselViewController.setGallery(galleryImages: galleryImages)
-        self.reviewCarouselViewController.setReview(reviews: reviews)
+    public func setGalleryAndReviewData(gallery: [Gallery], reviews: [UserReviewList], avgStars: Float) {
+        self.galleryCarouselViewController.setGallery(gallery: gallery)
+        self.reviewCarouselViewController.setReview(reviews: reviews, avgStars: avgStars)
         self.reviewCarouselViewController.setDelegate(self)
     }
 }

--- a/SNAPFIT/SNAPFIT/Sources/Components/TableViewCells/BorderedTableViewCell.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Components/TableViewCells/BorderedTableViewCell.swift
@@ -21,13 +21,13 @@ class BorderedTableViewCell: UITableViewCell {
         self.layer.cornerRadius = 8
     }
     
-    func setAsFavoriteList(userImage: UIImage?, userName: String) {
-        self.setPicture(userImage)
+    func setAsFavoriteList(userImageUrl: String?, userName: String) {
+        self.setPicture(userImageUrl)
         self.setFavoriteUserName(name: userName)
     }
     
-    private func setPicture(_ newImage: UIImage?) {
-        if let image = newImage { self.picture.image = image }
+    private func setPicture(_ newImageUrl: String?) {
+        if let imageUrl = newImageUrl { self.picture.setImageUrl(imageUrl) }
         self.picture.backgroundColor = .sfBlack20
         self.picture.layer.cornerRadius = 20
         self.picture.layer.borderWidth = 1

--- a/SNAPFIT/SNAPFIT/Sources/Screens/FavoriteList/FavoriteListViewController.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Screens/FavoriteList/FavoriteListViewController.swift
@@ -22,9 +22,6 @@ class FavoriteListViewController: BaseViewController {
         super.viewDidLoad()
         self.setNavigationTitle()
         self.setTableView()
-        ReservationService.shared.getReservationDetail(reservationId: 10) { data in
-            print(data)
-        }
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/SNAPFIT/SNAPFIT/Sources/Screens/FavoriteList/FavoriteListViewController.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Screens/FavoriteList/FavoriteListViewController.swift
@@ -8,6 +8,8 @@
 import UIKit
 
 class FavoriteListViewController: BaseViewController {
+    
+    private var likeList: [LikeListResponseDTOElement] = []
     let favoriteListTableView: UITableView = {
         let favoriteListTableView: UITableView = UITableView()
         favoriteListTableView.backgroundColor = .clear
@@ -27,6 +29,24 @@ class FavoriteListViewController: BaseViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.navigationController?.navigationBar.isHidden = false
+        LikeService.shared.getLikeList { networkResult in
+            switch networkResult {
+            case .success(let responseData):
+                if let result = responseData as? LikeListResponseDTO {
+                    self.likeList = result
+                    self.favoriteListTableView.reloadData()
+                    print(result)
+                }
+            case .requestErr(_):
+                print("requestError")
+            case .pathErr:
+                print("pathErr")
+            case .serverErr:
+                print("serverErr")
+            case .networkFail:
+                print("networkErr")
+            }
+        }
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -62,16 +82,17 @@ extension FavoriteListViewController: UITableViewDelegate {
         82
     }
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let currentUser = users[indexPath.row]
-        if currentUser.isPhotographer {
+        let currentUserID = likeList[indexPath.row].targetID
+        // TODO: [PROFILE] 프로필 포지션 알게 되면 포지션 따라서로 변경
+        if currentUserID % 2 == 0 {
             lazy var profileViewController: ProfilePhotographerViewController = ProfilePhotographerViewController()
             profileViewController.modalPresentationStyle = .fullScreen
-            profileViewController.setUserInformation(currentUser: currentUser)
+            profileViewController.setUserInformation(targetID: 24)
             self.navigationController?.pushViewController(profileViewController, animated: true)
         } else {
             lazy var profileViewController: ProfileGeneralUserViewController = ProfileGeneralUserViewController()
             profileViewController.modalPresentationStyle = .fullScreen
-            profileViewController.setUserInformation(currentUser: currentUser)
+            profileViewController.setUserInformation(targetID: 11)
             self.navigationController?.pushViewController(profileViewController, animated: true)
         }
     }
@@ -79,11 +100,11 @@ extension FavoriteListViewController: UITableViewDelegate {
 
 extension FavoriteListViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return favorites.count
+        return self.likeList.count
     }
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "favoriteListTableViewCell") as! BorderedTableViewCell
-        cell.setAsFavoriteList(userImage: favorites[indexPath.row].profileImage, userName: "\(favorites[indexPath.row].userName)")
+        cell.setAsFavoriteList(userImageUrl: likeList[indexPath.row].profileImageUrl, userName: likeList[indexPath.row].nickname)
         return cell
     }
 }

--- a/SNAPFIT/SNAPFIT/Sources/Screens/Mypage/MypageGeneralUserViewController.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Screens/Mypage/MypageGeneralUserViewController.swift
@@ -86,7 +86,7 @@ class MypageGeneralUserViewController: SnapfitUserInformationViewController {
         )
         self.setMailText(text: currentUser.emailAddress ?? "")
         self.setIntroduceText(text: currentUser.introduceText ?? "")
-        self.setGalleryAndReviewData(galleryImages: self.galleryImages, reviews: self.reviewData)
+//        self.setGalleryAndReviewData(galleryImages: self.galleryImages, reviews: self.reviewData)
     }
     
     private func setEditButtonAction() {

--- a/SNAPFIT/SNAPFIT/Sources/Screens/Mypage/MypageGeneralUserViewController.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Screens/Mypage/MypageGeneralUserViewController.swift
@@ -78,15 +78,18 @@ class MypageGeneralUserViewController: SnapfitUserInformationViewController {
     }
     
     public func setMypageData() {
-        self.setProfileImage(profileImage: self.profileImage)
-        self.setBasicData(
-            isApproved: true,
-            nicknameText: currentUser.userName,
-            instagramText: currentUser.instagramID
-        )
-        self.setMailText(text: currentUser.emailAddress ?? "")
-        self.setIntroduceText(text: currentUser.introduceText ?? "")
-//        self.setGalleryAndReviewData(galleryImages: self.galleryImages, reviews: self.reviewData)
+        getMyUserData { result in
+            self.setNickname(text: result.nickname)
+            self.setApproved(approveState: true)
+            self.setInstagramText(text: result.instagramId)
+            self.setMailText(text: result.email)
+            self.setIntroduceText(text: result.info ?? "")
+            self.setPossibleDateText(text: "")
+            self.setPriceText(text: result.cost ?? "")
+            self.setProfileImage(profileImage: result.profileImageUrl)
+            self.setBannerImage(bannerImage: result.thumbnailImageUrl)
+            self.setGalleryAndReviewData(gallery: result.gallery, reviews: result.review, avgStars: result.averageStars ?? 0)
+        }
     }
     
     private func setEditButtonAction() {

--- a/SNAPFIT/SNAPFIT/Sources/Screens/Mypage/MypageGeneralUserViewController.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Screens/Mypage/MypageGeneralUserViewController.swift
@@ -88,6 +88,18 @@ class MypageGeneralUserViewController: SnapfitUserInformationViewController {
             self.setPriceText(text: result.cost ?? "")
             self.setProfileImage(profileImage: result.profileImageUrl)
             self.setBannerImage(bannerImage: result.thumbnailImageUrl)
+            if result.averageStars != 0.0 {
+                ReviewService.shared.getReviewList(userId: UserInfo.shared.userID) { networkResult in
+                    switch networkResult {
+                    case .success(let responseData):
+                        if let result = responseData as? ReviewListResponseDTO {
+                            self.setGptData(gptReview: result.gptReview)
+                        }
+                    default:
+                        print("DEFAULT")
+                    }
+                }
+            }
             self.setGalleryAndReviewData(gallery: result.gallery, reviews: result.review, avgStars: result.averageStars ?? 0)
         }
     }

--- a/SNAPFIT/SNAPFIT/Sources/Screens/Mypage/MypagePhotographerViewController.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Screens/Mypage/MypagePhotographerViewController.swift
@@ -54,16 +54,15 @@ class MypagePhotographerViewController: SnapfitUserInformationViewController {
     public func setMypageData() {
         getMyUserData { result in
             self.setNickname(text: result.nickname)
-//            self.setApproved(approveState: result.)
+            self.setApproved(approveState: true)
             self.setInstagramText(text: result.instagramId)
             self.setMailText(text: result.email)
             self.setIntroduceText(text: result.info ?? "")
-            self.setPossibleDateText(text: "")
+            self.setPossibleDateText(text: "아~ 힘드네요")
             self.setPriceText(text: result.cost ?? "")
-            self.setProfileImage(profileImage: UIImage())
-            self.setBannerImage(bannerImage: result.thumbnailImage)
+            self.setProfileImage(profileImage: result.profileImageUrl)
+            self.setBannerImage(bannerImage: result.thumbnailImageUrl)
             self.setGalleryAndReviewData(gallery: result.gallery, reviews: result.review, avgStars: result.averageStars ?? 0)
-            
         }
     }
     

--- a/SNAPFIT/SNAPFIT/Sources/Screens/Mypage/MypagePhotographerViewController.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Screens/Mypage/MypagePhotographerViewController.swift
@@ -15,46 +15,6 @@ class MypagePhotographerViewController: SnapfitUserInformationViewController {
         static let editTitle = "수정하기"
     }
     
-    // MARK: - Properties
- var currentUser: User = User(
-    userName: "스냅핏 스튜디오",
-    isApproved: true,
-    isPhotographer: true,
-    instagramID: "snap-fit",
-    emailAddress: "snap-fit.google.com",
-    introduceText: """
-    연인/우정 스냅 경력 3년
-    서울/경기 스냅 사진 전문
-    """,
-    possibleDateText: """
-    *** 6월은 마지막 주 주말만 가능! ***
-    
-    촬영은 주말만 가능. 촬영 후 보정본 받는 건 촬영 다음 주 목요일까지 가능합니다.
-    일찍 되면 일찍 되는대로 보내드려요.
-    """,
-    priceText: """
-    기본 필름 5장: 100000원
-        - 필름 원본 제공
-        - 마음에 드는 사진 선택 후 보정 5장 제공
-    기본 디지털 5장: 80000원
-        - 디지털 사진 원본 10장 제공
-        - 10장 중 보정본 5장 제공
-    
-    사진 추가 제공은 추가금 있음
-    보정본 장 당 5000원
-    원본 장 당 2000원
-    
-    서울, 경기 외 지역 출장 시 출장비 문의 후 결정
-    """)
-    let profileImage: UIImage = UIImage(named: "sampleImage23")!
-    let bannerImage: UIImage = UIImage(named: "sampleImage25")!
-    let galleryImages: [UIImage] = [UIImage(named: "sampleImage23")!, UIImage(named: "sampleImage26")!, UIImage(named: "sampleImage28")!, UIImage(named: "sampleImage29")!]
-    let reviewData: [Review] = [
-        Review(userName: "오인하", imageName: "sampleImage27", score: 4, contentText: "개인 프로필로 하나 찍었어요~"),
-        Review(userName: "한도윤", imageName: "sampleImage25", score: 5, contentText: "커플 스냅 사진 분위기 진짜 잘 맞아서 좋아요"),
-        Review(userName: "류태현", imageName: "sampleImage24", score: 5, contentText: "자연스러운 분위기 선호해서 마음에 듭니다"),
-        Review(userName: "민주영", imageName: "sampleImage28", score: 5, contentText: "분위기 있게 찍고 싶었는데 잘 나왔네요 ㅎㅎ")]
-    
     // MARK: - UIComponents
     private let settingButton: UIButton = {
         let button: UIButton = UIButton()
@@ -92,21 +52,25 @@ class MypagePhotographerViewController: SnapfitUserInformationViewController {
     }
     
     public func setMypageData() {
-        self.setNickname(text: self.currentUser.userName)
-        self.setApproved(approveState: self.currentUser.isApproved)
-        self.setInstagramText(text: self.currentUser.instagramID)
-        self.setMailText(text: self.currentUser.emailAddress!)
-        self.setIntroduceText(text:self.currentUser.introduceText ?? "")
-        self.setPossibleDateText(text:self.currentUser.possibleDateText ?? "")
-        self.setPriceText(text: self.currentUser.priceText ?? "")
-        self.setProfileImage(profileImage: self.profileImage)
-        self.setBannerImage(bannerImage: self.bannerImage)
-        self.setGalleryAndReviewData(galleryImages: self.galleryImages, reviews: self.reviewData)
+        getMyUserData { result in
+            self.setNickname(text: result.nickname)
+//            self.setApproved(approveState: result.)
+            self.setInstagramText(text: result.instagramId)
+            self.setMailText(text: result.email)
+            self.setIntroduceText(text: result.info ?? "")
+            self.setPossibleDateText(text: "")
+            self.setPriceText(text: result.cost ?? "")
+            self.setProfileImage(profileImage: UIImage())
+            self.setBannerImage(bannerImage: result.thumbnailImage)
+            self.setGalleryAndReviewData(gallery: result.gallery, reviews: result.review, avgStars: result.averageStars ?? 0)
+            
+        }
     }
     
     private func setEditButtonAction() {
         lazy var viewController: MypagePhotographerEditingViewController = MypagePhotographerEditingViewController()
-        viewController.setUserInformation(currentUser: currentUser)
+        // TODO: [Mypage] 마이페이지 수정 추가하기
+//        viewController.setUserInformation(currentUser: currentUser)
         viewController.sendUpdateDelegate = self
         viewController.modalPresentationStyle = .fullScreen
         self.editButton.setAction {
@@ -133,7 +97,7 @@ extension MypagePhotographerViewController: SendUpdateDelegate {
     func sendUpdate(data: Any?) {
         // TODO: user data 업데이트 코드
         guard let newUserData = data as? User else { return }
-        self.currentUser.userName = newUserData.userName
+//        self.currentUser.userName = newUserData.userName
         self.setNickname(text: newUserData.userName)
     }
 }

--- a/SNAPFIT/SNAPFIT/Sources/Screens/Mypage/MypagePhotographerViewController.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Screens/Mypage/MypagePhotographerViewController.swift
@@ -62,6 +62,18 @@ class MypagePhotographerViewController: SnapfitUserInformationViewController {
             self.setPriceText(text: result.cost ?? "")
             self.setProfileImage(profileImage: result.profileImageUrl)
             self.setBannerImage(bannerImage: result.thumbnailImageUrl)
+            if result.averageStars != 0.0 {
+                ReviewService.shared.getReviewList(userId: UserInfo.shared.userID) { networkResult in
+                    switch networkResult {
+                    case .success(let responseData):
+                        if let result = responseData as? ReviewListResponseDTO {
+                            self.setGptData(gptReview: result.gptReview)
+                        }
+                    default:
+                        print("DEFAULT")
+                    }
+                }
+            }
             self.setGalleryAndReviewData(gallery: result.gallery, reviews: result.review, avgStars: result.averageStars ?? 0)
         }
     }

--- a/SNAPFIT/SNAPFIT/Sources/Screens/Profile/ProfileGeneralUserViewController.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Screens/Profile/ProfileGeneralUserViewController.swift
@@ -50,6 +50,18 @@ class ProfileGeneralUserViewController: SnapfitUserInformationViewController {
                 mailText: result.email,
                 introduceText: result.info ?? ""
             )
+            if result.averageStars != 0.0 {
+                ReviewService.shared.getReviewList(userId: targetID) { networkResult in
+                    switch networkResult {
+                    case .success(let responseData):
+                        if let result = responseData as? ReviewListResponseDTO {
+                            self.setGptData(gptReview: result.gptReview)
+                        }
+                    default:
+                        print("DEFAULT")
+                    }
+                }
+            }
             self.setGalleryAndReviewData(gallery: result.gallery, reviews: result.review, avgStars: result.averageStars ?? 0.0)
         }
     }

--- a/SNAPFIT/SNAPFIT/Sources/Screens/Profile/ProfileGeneralUserViewController.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Screens/Profile/ProfileGeneralUserViewController.swift
@@ -38,9 +38,26 @@ class ProfileGeneralUserViewController: SnapfitUserInformationViewController {
     }
     
     // MARK: - Methods
+    public func setUserInformation(targetID: Int) {
+        getUserData(targetID: targetID) { result in
+            self.setProfileImage(profileImage: result.profileImageUrl)
+            self.setBasicData(
+                isApproved: true,
+                nicknameText: result.nickname,
+                instagramText: result.instagramId
+            )
+            self.setAdditionalData(
+                mailText: result.email,
+                introduceText: result.info ?? ""
+            )
+            self.setGalleryAndReviewData(gallery: result.gallery, reviews: result.review, avgStars: result.averageStars ?? 0.0)
+        }
+    }
+    
     public func setUserInformation(currentUser: User) {
         self.currentUser = currentUser
-        self.setProfileImage(profileImage: currentUser.profileImage)
+        //        self.setProfileImage(profileImage: currentUser.profileImage.)
+        //        self.setBannerImage(bannerImage: currentUser.backgroundImage)
         self.setBasicData(
             isApproved: true,
             nicknameText: currentUser.userName,
@@ -50,7 +67,7 @@ class ProfileGeneralUserViewController: SnapfitUserInformationViewController {
             mailText: currentUser.emailAddress ?? "",
             introduceText: currentUser.introduceText ?? ""
         )
-//        self.setGalleryAndReviewData(galleryImages: currentUser.gallery, reviews: currentUser.reviews)
+        //        self.setGalleryAndReviewData(galleryImages: currentUser.gallery, reviews: currentUser.reviews)
     }
     
     private func setAdditionalData(mailText: String,introduceText: String) {
@@ -61,6 +78,7 @@ class ProfileGeneralUserViewController: SnapfitUserInformationViewController {
     private func setContactButtonAction() {
         self.contactButton.setAction {
             lazy var suggestionViewController: ReservationSuggestionViewController = ReservationSuggestionViewController()
+            // TODO: [RESERVATION] 예약 버튼 클릭 후 동작 
 //            suggestionViewController.setUserData(user: self.currentUser)
             suggestionViewController.modalTransitionStyle = .crossDissolve
             suggestionViewController.modalPresentationStyle = .overFullScreen

--- a/SNAPFIT/SNAPFIT/Sources/Screens/Profile/ProfileGeneralUserViewController.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Screens/Profile/ProfileGeneralUserViewController.swift
@@ -50,7 +50,7 @@ class ProfileGeneralUserViewController: SnapfitUserInformationViewController {
             mailText: currentUser.emailAddress ?? "",
             introduceText: currentUser.introduceText ?? ""
         )
-        self.setGalleryAndReviewData(galleryImages: currentUser.gallery, reviews: currentUser.reviews)
+//        self.setGalleryAndReviewData(galleryImages: currentUser.gallery, reviews: currentUser.reviews)
     }
     
     private func setAdditionalData(mailText: String,introduceText: String) {
@@ -61,7 +61,7 @@ class ProfileGeneralUserViewController: SnapfitUserInformationViewController {
     private func setContactButtonAction() {
         self.contactButton.setAction {
             lazy var suggestionViewController: ReservationSuggestionViewController = ReservationSuggestionViewController()
-            suggestionViewController.setUserData(user: self.currentUser)
+//            suggestionViewController.setUserData(user: self.currentUser)
             suggestionViewController.modalTransitionStyle = .crossDissolve
             suggestionViewController.modalPresentationStyle = .overFullScreen
             self.present(suggestionViewController, animated: true)

--- a/SNAPFIT/SNAPFIT/Sources/Screens/Profile/ProfilePhotographerViewController.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Screens/Profile/ProfilePhotographerViewController.swift
@@ -39,6 +39,25 @@ class ProfilePhotographerViewController: SnapfitUserInformationViewController {
     }
     
     // MARK: - Methods
+    public func setUserInformation() {
+        getMyUserData { result in
+            self.setProfileImage(profileImage: result.profileImage)
+            self.setBannerImage(bannerImage: result.thumbnailImage)
+            self.setBasicData(
+                isApproved: true,
+                nicknameText: result.nickname,
+                instagramText: result.instagramId
+            )
+            self.setAdditionalData(
+                mailText: result.email,
+                introduceText: result.info ?? "",
+                possibleDateText: "",
+                priceText: result.cost ?? ""
+            )
+            //            self.setGalleryAndReviewData(galleryImages: result.gallery, reviews: result.review)
+        }
+    }
+    
     public func setUserInformation(currentUser: User) {
         self.currentUser = currentUser
         self.setProfileImage(profileImage: currentUser.profileImage)
@@ -54,7 +73,7 @@ class ProfilePhotographerViewController: SnapfitUserInformationViewController {
             possibleDateText: currentUser.possibleDateText ?? "",
             priceText: currentUser.priceText ?? ""
         )
-        self.setGalleryAndReviewData(galleryImages: currentUser.gallery, reviews: currentUser.reviews)
+//        self.setGalleryAndReviewData(galleryImages: currentUser.gallery, reviews: currentUser.reviews)
     }
     
     private func setAdditionalData(mailText: String,introduceText: String, possibleDateText: String, priceText: String) {
@@ -83,7 +102,6 @@ class ProfilePhotographerViewController: SnapfitUserInformationViewController {
     private func setContactButtonAction() {
         self.contactButton.setAction {
             lazy var suggestionViewController: ReservationSuggestionViewController = ReservationSuggestionViewController()
-            suggestionViewController.setUserData(user: self.currentUser)
             suggestionViewController.modalTransitionStyle = .crossDissolve
             suggestionViewController.modalPresentationStyle = .overFullScreen
             self.present(suggestionViewController, animated: true)

--- a/SNAPFIT/SNAPFIT/Sources/Screens/Profile/ProfilePhotographerViewController.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Screens/Profile/ProfilePhotographerViewController.swift
@@ -39,10 +39,10 @@ class ProfilePhotographerViewController: SnapfitUserInformationViewController {
     }
     
     // MARK: - Methods
-    public func setUserInformation() {
-        getMyUserData { result in
-            self.setProfileImage(profileImage: result.profileImage)
-            self.setBannerImage(bannerImage: result.thumbnailImage)
+    public func setUserInformation(targetID: Int) {
+        getUserData(targetID: targetID) { result in
+            self.setProfileImage(profileImage: result.profileImageUrl)
+            self.setBannerImage(bannerImage: result.thumbnailImageUrl)
             self.setBasicData(
                 isApproved: true,
                 nicknameText: result.nickname,
@@ -51,17 +51,29 @@ class ProfilePhotographerViewController: SnapfitUserInformationViewController {
             self.setAdditionalData(
                 mailText: result.email,
                 introduceText: result.info ?? "",
-                possibleDateText: "",
+                possibleDateText: "dd",
                 priceText: result.cost ?? ""
             )
-            //            self.setGalleryAndReviewData(galleryImages: result.gallery, reviews: result.review)
+            if result.averageStars != 0.0 {
+                ReviewService.shared.getReviewList(userId: targetID) { networkResult in
+                    switch networkResult {
+                    case .success(let responseData):
+                        if let result = responseData as? ReviewListResponseDTO {
+                            self.setGptData(gptReview: result.gptReview)
+                        }
+                    default:
+                        print("DEFAULT")
+                    }
+                }
+            }
+            self.setGalleryAndReviewData(gallery: result.gallery, reviews: result.review, avgStars: result.averageStars ?? 0.0)
         }
     }
     
     public func setUserInformation(currentUser: User) {
         self.currentUser = currentUser
-        self.setProfileImage(profileImage: currentUser.profileImage)
-        self.setBannerImage(bannerImage: currentUser.backgroundImage)
+//        self.setProfileImage(profileImage: currentUser.profileImage.)
+//        self.setBannerImage(bannerImage: currentUser.backgroundImage)
         self.setBasicData(
             isApproved: true,
             nicknameText: currentUser.userName,

--- a/SNAPFIT/SNAPFIT/Sources/Screens/Profile/ReservationSuggestionViewController.swift
+++ b/SNAPFIT/SNAPFIT/Sources/Screens/Profile/ReservationSuggestionViewController.swift
@@ -30,7 +30,6 @@ class ReservationSuggestionViewController: BaseViewController, DateDataDelegate 
         static let errorMessage = "필요한 내용을 전부 채워주세요."
     }
     
-    var currentUser: User!
     let reservationDateFormatter: DateFormatter = {
         let formatter: DateFormatter = DateFormatter()
         formatter.dateFormat = Text.reservationDateFormat
@@ -129,9 +128,8 @@ class ReservationSuggestionViewController: BaseViewController, DateDataDelegate 
             } else {
                 
                 self.makeAlert(title: Text.completeTitle, message: Text.completeMessage, okAction: { _ in
-                    reservationData.append(Reservation(recieverID: users.firstIndex(where: {$0.userName == self.currentUser.userName}) ?? 0, dateText: self.dateTextView.text, lastUpdateText: "\(self.lastDateFormatter.string(from: Date()))"))
-                    self.dismiss(animated: true)
-                    print(reservationData.count)
+                    // TODO: [RESERVATION] 예약 보내기 기능 연결
+                    print("TODO: [RESERVATION] 예약 보내기 기능 연결하자")
                 })
             }
         }
@@ -152,10 +150,6 @@ class ReservationSuggestionViewController: BaseViewController, DateDataDelegate 
     
     public func recieveDateData(date: Date) {
         self.dateTextView.text = self.reservationDateFormatter.string(from: date)
-    }
-    
-    public func setUserData(user: User) {
-        self.currentUser = user
     }
     
     // MARK: - Layout Methods


### PR DESCRIPTION
## 작업한 내용
- 마이페이지, 프로필 기본정보 서버 통신값으로 보여주기
- 관심목록 서버 값으로 보여주기(상세 연결은 24,11, 22로 고정)
- GPT 적용 UI 변경
- 사진 안뜨던 것들 보니 링크된 이미지가 404 뜨는 이미지여서 그런 듯 합니다

## PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 서버쪽에서 position 정보를 관심목록 줄 때도 줘야할 거 같아서 이 부분은 임시로 처리해둔 상태 (스샷 마지막)
- 촬영가능날짜와 가격 정보는 어차피 사용자 수정 시 서버에서 notNull로 무조건 기입이라 일단 둘 다 있다는 가정하에 작성
- 갤러리가 없다고 생각한 경우의 대응을 해야하나? (스샷 중간 부분) 그런데 사진을 넣어서 실험해보려니까 스웨거에서 서버 내 오류로 뜨던데 현재 이렇게 되는게 맞는지 잘 모르겠어서 보류.

## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
예쁘게 띄워진 GPT~~~~~
![simulator_screenshot_A761CA89-B917-4750-8E28-E540D1B1CC6F](https://github.com/2023-SWU-Snapfit/SNAPFIT-iOS/assets/86394389/c7c4a5ac-f66b-4e68-9544-b811bb77fb0c)

- 촬영가능날짜. 가격 정보 필수 기재 형태로 전환. (안써도 빈 칸으로 구조는 있음. 사진 참고.) 근데 우리 서버쪽 유저 수정할 때 어차피 notnull이라 이렇게 해도 되지 않을까
- 그리고 갤러리 부분이 사진처럼 비게 되는데 이걸... 줄이도록....할까? 근데 사진 넣어보려고 하니까 스웨거에서는 사진 추가가 서버 내 오류 떠서 원래 이런 게 맞는지 확인해봐야한다.
![simulator_screenshot_4279188B-1ACA-4EC7-817F-E92E2C7BF3FA](https://github.com/2023-SWU-Snapfit/SNAPFIT-iOS/assets/86394389/cebcb414-8d53-487c-83ac-ef99e179b9a6)
![simulator_screenshot_E3F62739-FF11-49BC-871C-5DB1FE00208D](https://github.com/2023-SWU-Snapfit/SNAPFIT-iOS/assets/86394389/4ed0d272-fb9b-4fe9-aa7e-f7f3c0fc1f4f)

- gpt 텍뷰 크기에 따라 기존 UI 아래로 미뤄짐. 현재 서버에서 gpt 리뷰가 기본 값이 다 있어서 gpt 요약이 있는 경우로 가정하고 대응.
![simulator_screenshot_6A272F2B-1264-4091-B1F4-AD3281B0F6A3](https://github.com/2023-SWU-Snapfit/SNAPFIT-iOS/assets/86394389/598d304c-3d0f-41cb-837f-51d496345c7f)

- 주석 내용처럼 아직 position정보는 알 수가 없어서 프로필 페이지 확인을 위해 임시로 대처
<img width="733" alt="image" src="https://github.com/2023-SWU-Snapfit/SNAPFIT-iOS/assets/86394389/058e62aa-996e-4b5c-b0a3-58b9bafb1572">


## 관련 이슈
- Resolved: #42


<!-- Assignee, Reviewer 설정! 😇 -->
